### PR TITLE
Combine VE log modes

### DIFF
--- a/src/com/vgi/mafscaling/ClosedLoop.java
+++ b/src/com/vgi/mafscaling/ClosedLoop.java
@@ -1083,12 +1083,13 @@ public class ClosedLoop extends AMafScaling {
                             dVdt = 100.0;
                         else
                             dVdt = Math.abs(((mafv - pmafv) / (time - prevTime)) * 1000.0);
-                        if (flds[logClOlStatusColIdx] == "on")
+                        String clStr = flds[logClOlStatusColIdx];
+                        if (clStr.equalsIgnoreCase("on"))
                             clol = 0;
-                        else if (flds[logClOlStatusColIdx] == "off")
+                        else if (clStr.equalsIgnoreCase("off"))
                             clol = 1;
                         else
-                            clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                            clol = (int)Utils.parseValue(clStr);
                         if (clol == clValue) {
                             // Filters
                             afr = Double.valueOf(flds[logAfrColIdx]);

--- a/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
@@ -106,6 +106,9 @@ abstract class ColumnsFiltersSelection implements ActionListener {
     public static final String minWOTEnrichmentLabelText = "Min WOT Enrichment";
     public static final String wbo2RowOffsetLabelText = "Wideband AFR Row Offset";
     public static final String olClTransitionSkipRowsLabelText = "OL/CL Transition - #Rows to Skip";
+    public static final String afrMpSwitchLabelText = "WB AFR MP Switch";
+    public static final String afrRpmSwitchLabelText = "WB AFR RPM Switch";
+    public static final String afrSmoothLabelText = "WB AFR Transition Smooth";
     protected JTable columnsTable = null;
     protected JTextField thrtlAngleName = null;
     protected JTextField afLearningName = null;
@@ -142,6 +145,9 @@ abstract class ColumnsFiltersSelection implements ActionListener {
     protected JFormattedTextField olClTransitionSkipRowsField = null;
     protected JFormattedTextField maxAfrFilter = null;
     protected JFormattedTextField minAfrFilter = null;
+    protected JFormattedTextField afrMpSwitchFilter = null;
+    protected JFormattedTextField afrRpmSwitchFilter = null;
+    protected JFormattedTextField afrSmoothFilter = null;
     protected JFormattedTextField atmPressureFilter = null;
     protected JFormattedTextField maxIatFilter = null;
     protected JFormattedTextField maxDvdtFilter = null;
@@ -681,6 +687,27 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         addLabel(filtersPanel, ++filtrow, wbo2RowOffsetLabelText);
         wbo2RowOffsetField = addTextFilter(filtrow, intFmt);
         addDefaultButton(filtrow, "wbo2offset");
+    }
+
+    protected void addAfrMpSwitchFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "MP where WB AFR starts to blend in");
+        addLabel(filtersPanel, ++filtrow, afrMpSwitchLabelText);
+        afrMpSwitchFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "wbswitchmp");
+    }
+
+    protected void addAfrRpmSwitchFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "RPM where WB AFR starts to blend in");
+        addLabel(filtersPanel, ++filtrow, afrRpmSwitchLabelText);
+        afrRpmSwitchFilter = addTextFilter(filtrow, intFmt);
+        addDefaultButton(filtrow, "wbswitchrpm");
+    }
+
+    protected void addAfrSmoothFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Smoothing range for WB/Stock AFR switch");
+        addLabel(filtersPanel, ++filtrow, afrSmoothLabelText);
+        afrSmoothFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "wbsmooth");
     }
     
     protected void addOLCLTransitionSkipRowsFilter() {

--- a/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
@@ -108,7 +108,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
     public static final String olClTransitionSkipRowsLabelText = "OL/CL Transition - #Rows to Skip";
     public static final String afrMpSwitchLabelText = "WB AFR MP Switch";
     public static final String afrRpmSwitchLabelText = "WB AFR RPM Switch";
-    public static final String afrSmoothLabelText = "WB AFR Transition Smooth";
+    public static final String afrSmoothLabelText = "WB AFR Blend Range";
     protected JTable columnsTable = null;
     protected JTextField thrtlAngleName = null;
     protected JTextField afLearningName = null;
@@ -704,7 +704,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
     }
 
     protected void addAfrSmoothFilter() {
-        addNote(filtersPanel, ++filtrow, 3, "Smoothing range for WB/Stock AFR switch");
+        addNote(filtersPanel, ++filtrow, 3, "Blend transition range for switching Stock/WB AFR");
         addLabel(filtersPanel, ++filtrow, afrSmoothLabelText);
         afrSmoothFilter = addTextFilter(filtrow, doubleFmt);
         addDefaultButton(filtrow, "wbsmooth");

--- a/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
@@ -771,7 +771,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         return current;
     }
 
-    private void addCommentLabel(JPanel panel, int row, int colspan, String text) {
+    protected void addCommentLabel(JPanel panel, int row, int colspan, String text) {
         JLabel label = new JLabel(text);
         GridBagConstraints gbc_label = new GridBagConstraints();
         gbc_label.anchor = GridBagConstraints.WEST;
@@ -783,7 +783,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         panel.add(label, gbc_label);
     }
     
-    private void addLabel(JPanel panel, int row, String text) {
+    protected void addLabel(JPanel panel, int row, String text) {
         JLabel label = new JLabel(text);
         GridBagConstraints gbc_label = new GridBagConstraints();
         gbc_label.anchor = GridBagConstraints.EAST;
@@ -793,7 +793,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         panel.add(label, gbc_label);
     }
     
-    private void addNote(JPanel panel, int row, int colspan, String note) {
+    protected void addNote(JPanel panel, int row, int colspan, String note) {
         JEditorPane label = createWrapLabel(note);
         GridBagConstraints gbc_label = new GridBagConstraints();
         gbc_label.anchor = GridBagConstraints.WEST;
@@ -848,7 +848,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         columnsPanel.add(button, gbc_button);
     }
 
-    private JFormattedTextField addTextFilter(int row, NumberFormat format) {
+    protected JFormattedTextField addTextFilter(int row, NumberFormat format) {
         JFormattedTextField textField = new JFormattedTextField(format);
         textField.setColumns(6);
         textField.setBackground(Color.WHITE);
@@ -899,7 +899,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         return flag;
     }
     
-    private void addDefaultButton(int row, String action) {
+    protected void addDefaultButton(int row, String action) {
         JButton button = new JButton("default");
         GridBagConstraints gbc_button = new GridBagConstraints();
         gbc_button.anchor = GridBagConstraints.WEST;

--- a/src/com/vgi/mafscaling/Config.java
+++ b/src/com/vgi/mafscaling/Config.java
@@ -79,6 +79,7 @@ public class Config {
     public static final String DefaultVEOlAfrMaximum = "16.0";
     public static final String DefaultVEClAfrMaximum = "15.0";
     public static final String DefaultVEAfrMinimum = "13.7";
+    public static final String DefaultVEFullTimeOL = "false";
     public static final String DefaultLoadMinimum = "0.2";
     public static final String DefaultDvDtMaximum = "0.7";
     public static final String DefaultMIAfrMaximum = "16.0";
@@ -88,6 +89,7 @@ public class Config {
     private static final String CFG_FILE = "config.xml";
     public static final String NO_NAME = "#$#";
     private static Properties props = new Properties();
+    public static boolean veFullTimeOl = false;
 
     public static String getProperty(String name) {
         return props.getProperty(name, "");
@@ -819,6 +821,14 @@ public class Config {
 
     public static void setVVT2RPMColumn(String s) {
         props.setProperty("VVT2RPMColumn", s);
+    }
+
+    public static boolean veFullTimeOl() {
+        return veFullTimeOl;
+    }
+
+    public static void veFullTimeOl(boolean f) {
+        veFullTimeOl = f;
     }
     
     

--- a/src/com/vgi/mafscaling/Config.java
+++ b/src/com/vgi/mafscaling/Config.java
@@ -88,7 +88,6 @@ public class Config {
     private static final String CFG_FILE = "config.xml";
     public static final String NO_NAME = "#$#";
     private static Properties props = new Properties();
-    public static boolean veOpenLoop = true;
 
     public static String getProperty(String name) {
         return props.getProperty(name, "");
@@ -822,13 +821,6 @@ public class Config {
         props.setProperty("VVT2RPMColumn", s);
     }
     
-    public static boolean veOpenLoop() {
-        return veOpenLoop;
-    }
-    
-    public static void veOpenLoop(boolean f) {
-        veOpenLoop = f;
-    }
     
     public static String getEncoding() {
         return props.getProperty("Encoding", DefaultEncoding);

--- a/src/com/vgi/mafscaling/Config.java
+++ b/src/com/vgi/mafscaling/Config.java
@@ -79,6 +79,8 @@ public class Config {
     public static final String DefaultVEOlAfrMaximum = "16.0";
     public static final String DefaultVEClAfrMaximum = "15.0";
     public static final String DefaultVEAfrMinimum = "13.7";
+    public static final String DefaultVEOlAfrMinimum = "10.0";
+    public static final String DefaultVEClAfrMinimum = "13.7";
     public static final String DefaultVEFullTimeOL = "false";
     // Default thresholds for blending stock and wideband AFR when Full Time OL mode is enabled
     public static final String DefaultVEWbAfrMpSwitch = "1.0";   // MP at which WB AFR blend starts
@@ -753,6 +755,22 @@ public class Config {
 
     public static void setVEClAfrMaximumValue(double v) {
         props.setProperty("VEClAfrMaximum", Double.toString(v));
+    }
+
+    public static double getVEOlAfrMinimumValue() {
+        return Double.parseDouble(props.getProperty("VEOlAfrMinimum", DefaultVEOlAfrMinimum));
+    }
+
+    public static void setVEOlAfrMinimumValue(double v) {
+        props.setProperty("VEOlAfrMinimum", Double.toString(v));
+    }
+
+    public static double getVEClAfrMinimumValue() {
+        return Double.parseDouble(props.getProperty("VEClAfrMinimum", DefaultVEClAfrMinimum));
+    }
+
+    public static void setVEClAfrMinimumValue(double v) {
+        props.setProperty("VEClAfrMinimum", Double.toString(v));
     }
 
     public static double getVEAfrMinimumValue() {

--- a/src/com/vgi/mafscaling/Config.java
+++ b/src/com/vgi/mafscaling/Config.java
@@ -80,6 +80,9 @@ public class Config {
     public static final String DefaultVEClAfrMaximum = "15.0";
     public static final String DefaultVEAfrMinimum = "13.7";
     public static final String DefaultVEFullTimeOL = "false";
+    public static final String DefaultVEWbAfrMpSwitch = "0.0";
+    public static final String DefaultVEWbAfrRpmSwitch = "0";
+    public static final String DefaultVEWbAfrSmooth = "0.0";
     public static final String DefaultLoadMinimum = "0.2";
     public static final String DefaultDvDtMaximum = "0.7";
     public static final String DefaultMIAfrMaximum = "16.0";
@@ -541,6 +544,30 @@ public class Config {
 
     public static void setWBO2RowOffset(int v) {
         props.setProperty("WBO2RowOffset", Integer.toString(v));
+    }
+
+    public static double getVEWbAfrMpSwitch() {
+        return Double.parseDouble(props.getProperty("VEWbAfrMpSwitch", DefaultVEWbAfrMpSwitch));
+    }
+
+    public static void setVEWbAfrMpSwitch(double v) {
+        props.setProperty("VEWbAfrMpSwitch", Double.toString(v));
+    }
+
+    public static int getVEWbAfrRpmSwitch() {
+        return Integer.parseInt(props.getProperty("VEWbAfrRpmSwitch", DefaultVEWbAfrRpmSwitch));
+    }
+
+    public static void setVEWbAfrRpmSwitch(int v) {
+        props.setProperty("VEWbAfrRpmSwitch", Integer.toString(v));
+    }
+
+    public static double getVEWbAfrSmooth() {
+        return Double.parseDouble(props.getProperty("VEWbAfrSmooth", DefaultVEWbAfrSmooth));
+    }
+
+    public static void setVEWbAfrSmooth(double v) {
+        props.setProperty("VEWbAfrSmooth", Double.toString(v));
     }
 
     public static int getOLCLTransitionSkipRows() {

--- a/src/com/vgi/mafscaling/Config.java
+++ b/src/com/vgi/mafscaling/Config.java
@@ -80,9 +80,10 @@ public class Config {
     public static final String DefaultVEClAfrMaximum = "15.0";
     public static final String DefaultVEAfrMinimum = "13.7";
     public static final String DefaultVEFullTimeOL = "false";
-    public static final String DefaultVEWbAfrMpSwitch = "0.0";
-    public static final String DefaultVEWbAfrRpmSwitch = "0";
-    public static final String DefaultVEWbAfrSmooth = "0.0";
+    // Default thresholds for blending stock and wideband AFR when Full Time OL mode is enabled
+    public static final String DefaultVEWbAfrMpSwitch = "1.0";   // MP at which WB AFR blend starts
+    public static final String DefaultVEWbAfrRpmSwitch = "3000"; // RPM at which WB AFR blend starts
+    public static final String DefaultVEWbAfrSmooth = "0.3";    // Range over which blend transitions
     public static final String DefaultLoadMinimum = "0.2";
     public static final String DefaultDvDtMaximum = "0.7";
     public static final String DefaultMIAfrMaximum = "16.0";

--- a/src/com/vgi/mafscaling/MafIatComp.java
+++ b/src/com/vgi/mafscaling/MafIatComp.java
@@ -372,12 +372,13 @@ public class MafIatComp extends ACompCalc {
                             else if (row <= 2 || Math.abs(ppThrottle - throttle) <= thrtlMaxChange2) {
                                 // Filters
                                 trims = Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]);
-                                if (flds[logClOlStatusColIdx] == "on")
+                                String clStr = flds[logClOlStatusColIdx];
+                                if (clStr.equalsIgnoreCase("on"))
                                     clol = 0;
-                                else if (flds[logClOlStatusColIdx] == "off")
+                                else if (clStr.equalsIgnoreCase("off"))
                                     clol = 1;
                                 else
-                                    clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                    clol = (int)Utils.parseValue(clStr);
                                 if (clValue == clol) {
                                     afr = Double.valueOf(flds[logAfrColIdx]);
                                     corr = (100.0 + trims) / 100.0;

--- a/src/com/vgi/mafscaling/MafScaling.java
+++ b/src/com/vgi/mafscaling/MafScaling.java
@@ -46,6 +46,7 @@ public class MafScaling {
     private static final String LCTabName = "<html>Load Comp</html>";
     private static final String MITabName = "<html>MAF IAT Comp</html>";
     private static final String VETabName = "<html>MAF VE Calc</html>";
+    private static final String VEPlusTabName = "<html>VE+</html>";
     private static final String VCTabName = "<html>WOT Best VVT</html>";
     private static final String LSTabName = "<html>Log Stats</html>";
     private static final String LVTabName = "<html>Log View</html>";
@@ -156,6 +157,10 @@ public class MafScaling {
         JTabbedPane ve = new VECalc(JTabbedPane.LEFT);
         ve.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
         tabbedPane.add(ve, VETabName);
+
+        JTabbedPane vePlus = new VEPlusCalc(JTabbedPane.LEFT);
+        vePlus.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+        tabbedPane.add(vePlus, VEPlusTabName);
 
         JTabbedPane vc = new VVTCalc(JTabbedPane.LEFT);
         vc.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -92,6 +92,7 @@ public class VECalc extends ACompCalc {
     private double mpMin = Config.getVEMPMinimumValue();
     private double iatMax = Config.getVEIatMaximumValue();
     private int corrApplied = Config.getVECorrectionAppliedValue();
+    private boolean fullTimeOl = Config.veFullTimeOl();
     private int logClOlStatusColIdx = -1;
     private int logThrottleAngleColIdx = -1;
     private int logRpmColIdx = -1;
@@ -324,13 +325,14 @@ public class VECalc extends ACompCalc {
         logMafColIdx = columns.indexOf(logMafColName);
         logIatColIdx = columns.indexOf(logIatColName);
         logMpColIdx = columns.indexOf(logMpColName);
+        fullTimeOl = Config.veFullTimeOl();
         if (logThrottleAngleColIdx == -1)        { Config.setThrottleAngleColumnName(Config.NO_NAME);    ret = false; }
         if (logFfbColIdx == -1)                  { Config.setFinalFuelingBaseColumnName(Config.NO_NAME); ret = false; }
         if (logSdColIdx == -1)                   { Config.setVEFlowColumnName(Config.NO_NAME);           ret = false; }
         if (logWbAfrColIdx == -1)        { Config.setWidebandAfrColumnName(Config.NO_NAME);      ret = false; }
         if (logStockAfrColIdx == -1)    { Config.setAfrColumnName(Config.NO_NAME);              ret = false; }
-        if (logAfLearningColIdx == -1)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
-        if (logAfCorrectionColIdx == -1){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
+        if (logAfLearningColIdx == -1 && !fullTimeOl)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
+        if (logAfCorrectionColIdx == -1 && !fullTimeOl){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
         if (logRpmColIdx == -1)                  { Config.setRpmColumnName(Config.NO_NAME);              ret = false; }
         if (logMafColIdx == -1)                  { Config.setMassAirflowColumnName(Config.NO_NAME);      ret = false; }
         if (logMpColIdx == -1)                   { Config.setMpColumnName(Config.NO_NAME);               ret = false; }
@@ -446,7 +448,7 @@ public class VECalc extends ACompCalc {
                                 boolean flag = isClosed ? (afrMin <= afr && afr <= afrMaxCl) : ((afr <= afrMaxOl || throttle >= thrtlMin) && afr <= afrMaxOl);
                                 if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
                                     removed = false;
-                                    if (isClosed)
+                                    if (!fullTimeOl && isClosed)
                                         trims.add(Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]));
                                     else
                                         trims.add(Double.NaN);

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -444,12 +444,13 @@ public class VECalc extends ACompCalc {
                                 iat = Double.valueOf(flds[logIatColIdx]);
                                 boolean isClosed = false;
                                 if (!fullTimeOl) {
-                                    if (flds[logClOlStatusColIdx] == "on")
+                                    String clStr = flds[logClOlStatusColIdx];
+                                    if (clStr.equalsIgnoreCase("on"))
                                         clol = 0;
-                                    else if (flds[logClOlStatusColIdx] == "off")
+                                    else if (clStr.equalsIgnoreCase("off"))
                                         clol = 1;
                                     else
-                                        clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                        clol = (int)Utils.parseValue(clStr);
                                     isClosed = (clol == 0);
                                 }
                                 double afrStock = Double.valueOf(afrflds[logStockAfrColIdx]);
@@ -472,6 +473,7 @@ public class VECalc extends ACompCalc {
                                     else if (alpha > 1)
                                         alpha = 1;
                                     afrEff = afrStock * (1 - alpha) + afrWb * alpha;
+                                    isClosed = alpha < 0.5;
                                 }
 
                                 boolean flag = isClosed ? (afrMin <= afrEff && afrEff <= afrMaxCl) : ((afrEff <= afrMaxOl || throttle >= thrtlMin) && afrEff <= afrMaxOl);

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -88,7 +88,8 @@ public class VECalc extends ACompCalc {
     private double thrtlMin = Config.getVEThrottleMinimumValue();
     private double afrMaxOl = Config.getVEOlAfrMaximumValue();
     private double afrMaxCl = Config.getVEClAfrMaximumValue();
-    private double afrMin = Config.getVEAfrMinimumValue();
+    private double afrMinOl = Config.getVEOlAfrMinimumValue();
+    private double afrMinCl = Config.getVEClAfrMinimumValue();
     private double rpmMin = Config.getVERPMMinimumValue();
     private double ffbMax = Config.getFFBMaximumValue();
     private double ffbMin = Config.getFFBMinimumValue();
@@ -354,7 +355,8 @@ public class VECalc extends ACompCalc {
         thrtlMin = Config.getVEThrottleMinimumValue();
         afrMaxOl = Config.getVEOlAfrMaximumValue();
         afrMaxCl = Config.getVEClAfrMaximumValue();
-        afrMin = Config.getVEAfrMinimumValue();
+        afrMinOl = Config.getVEOlAfrMinimumValue();
+        afrMinCl = Config.getVEClAfrMinimumValue();
         afrRowOffset = Config.getWBO2RowOffset();
         corrApplied = Config.getVECorrectionAppliedValue();
         afrSwitchMp = Config.getVEWbAfrMpSwitch();
@@ -476,7 +478,8 @@ public class VECalc extends ACompCalc {
                                     isClosed = alpha < 0.5;
                                 }
 
-                                boolean flag = isClosed ? (afrMin <= afrEff && afrEff <= afrMaxCl) : ((afrEff <= afrMaxOl || throttle >= thrtlMin) && afrEff <= afrMaxOl);
+                                boolean flag = isClosed ? (afrMinCl <= afrEff && afrEff <= afrMaxCl)
+                                                     : (afrMinOl <= afrEff && afrEff <= afrMaxOl);
                                 if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
                                     removed = false;
                                     if (!fullTimeOl && isClosed)

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -75,6 +75,9 @@ public class VECalc extends ACompCalc {
         public double sd = 0;
         public double sderr = 0;
         public double afrerr = 0;
+        public double afrStock = 0;
+        public double afrWb = 0;
+        public int cl = 0;
     }
 
     private static final String xAxisName = "RPM";
@@ -109,7 +112,7 @@ public class VECalc extends ACompCalc {
     private int logFfbColIdx = -1;    
     private int logSdColIdx = -1;
     
-    private String[] logColumns = new String[] { "RPM", "IAT", "MP", "FFB", "AFR", "MAF", "VE" };
+    private String[] logColumns = new String[] { "RPM", "IAT", "MP", "FFB", "AFR", "WB", "AFRE", "MAF", "VE", "CL" };
     private JComboBox<String> sdType = null;
     private JComboBox<String> mpType = null;
     private JComboBox<String> dataType = null;
@@ -408,7 +411,6 @@ public class VECalc extends ACompCalc {
                 double throttle = 0;
                 double pThrottle = 0;
                 double ppThrottle = 0;
-                double afr = 0;
                 double rpm;
                 double ffb;
                 double iat;
@@ -449,11 +451,14 @@ public class VECalc extends ACompCalc {
                                     else
                                         clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
                                     isClosed = (clol == 0);
-                                    afr = isClosed ? Double.valueOf(afrflds[logStockAfrColIdx]) : Double.valueOf(afrflds[logWbAfrColIdx]);
+                                }
+                                double afrStock = Double.valueOf(afrflds[logStockAfrColIdx]);
+                                double afrWb = Double.valueOf(afrflds[logWbAfrColIdx]);
+                                double afrEff;
+                                if (!fullTimeOl) {
+                                    afrEff = isClosed ? afrStock : afrWb;
                                 } else {
                                     double mp = Double.valueOf(flds[logMpColIdx]);
-                                    double afrWb = Double.valueOf(afrflds[logWbAfrColIdx]);
-                                    double afrStock = Double.valueOf(afrflds[logStockAfrColIdx]);
                                     double alpha;
                                     if (afrSmooth <= 0)
                                         alpha = (rpm >= afrSwitchRpm || mp >= afrSwitchMp) ? 1.0 : 0.0;
@@ -466,9 +471,10 @@ public class VECalc extends ACompCalc {
                                         alpha = 0;
                                     else if (alpha > 1)
                                         alpha = 1;
-                                    afr = afrStock * (1 - alpha) + afrWb * alpha;
+                                    afrEff = afrStock * (1 - alpha) + afrWb * alpha;
                                 }
-                                boolean flag = isClosed ? (afrMin <= afr && afr <= afrMaxCl) : ((afr <= afrMaxOl || throttle >= thrtlMin) && afr <= afrMaxOl);
+
+                                boolean flag = isClosed ? (afrMin <= afrEff && afrEff <= afrMaxCl) : ((afrEff <= afrMaxOl || throttle >= thrtlMin) && afrEff <= afrMaxOl);
                                 if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
                                     removed = false;
                                     if (!fullTimeOl && isClosed)
@@ -480,9 +486,12 @@ public class VECalc extends ACompCalc {
                                     logDataTable.setValueAt(iat, row, 1);
                                     logDataTable.setValueAt(Double.valueOf(flds[logMpColIdx]), row, 2);
                                     logDataTable.setValueAt(ffb, row, 3);
-                                    logDataTable.setValueAt(afr, row, 4);
-                                    logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 5);
-                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, 6);
+                                    logDataTable.setValueAt(afrStock, row, 4);
+                                    logDataTable.setValueAt(afrWb, row, 5);
+                                    logDataTable.setValueAt(afrEff, row, 6);
+                                    logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 7);
+                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, 8);
+                                    logDataTable.setValueAt(isClosed ? 1 : 0, row, 9);
                                     row += 1;
                                 }
                                 else
@@ -533,7 +542,7 @@ public class VECalc extends ACompCalc {
             else if (mpStr.contains("Rel") && sdStr.contains("Cobb"))
                 mapO = 14.7;
 
-            String rpmStr, iatStr, afrStr, mafStr, ffbStr;
+            String rpmStr, iatStr, afreStr, mafStr, ffbStr, clStr;
             LogData logData;
             xData = new HashMap<Double, HashMap<Double, ArrayList<LogData>>>();
             HashMap<Double, ArrayList<LogData>> yData;
@@ -543,10 +552,11 @@ public class VECalc extends ACompCalc {
                 iatStr = logDataTable.getValueAt(i, 1).toString();
                 mpStr  = logDataTable.getValueAt(i, 2).toString();
                 ffbStr = logDataTable.getValueAt(i, 3).toString();
-                afrStr = logDataTable.getValueAt(i, 4).toString();
-                mafStr = logDataTable.getValueAt(i, 5).toString();
-                sdStr  = logDataTable.getValueAt(i, 6).toString();
-                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afrStr.isEmpty() || mafStr.isEmpty() || ffbStr.isEmpty() || sdStr.isEmpty())
+                afreStr = logDataTable.getValueAt(i, 6).toString();
+                mafStr = logDataTable.getValueAt(i, 7).toString();
+                sdStr  = logDataTable.getValueAt(i, 8).toString();
+                clStr  = logDataTable.getValueAt(i, 9).toString();
+                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afreStr.isEmpty() || mafStr.isEmpty() || ffbStr.isEmpty() || sdStr.isEmpty())
                     continue;
                 logData = new LogData();
                 logData.mp = (Double.valueOf(mpStr) * mapG) + mapO;
@@ -560,7 +570,12 @@ public class VECalc extends ACompCalc {
                 logData.iat = Double.valueOf(iatStr);
                 logData.maf = Double.valueOf(mafStr);
                 logData.sd = Double.valueOf(sdStr);
-                logData.afr = Double.valueOf(afrStr);
+                logData.afr = Double.valueOf(afreStr);
+                try {
+                    logData.cl = Integer.parseInt(clStr);
+                } catch (Exception ex) {
+                    logData.cl = 0;
+                }
                 logData.ffb = Double.valueOf(ffbStr);
                 logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
                 if (Double.isNaN(trims.get(i)))

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -27,6 +27,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Stroke;
 import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -39,6 +40,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.ResourceBundle;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -109,9 +112,10 @@ public class VECalc extends ACompCalc {
     private int logStockAfrColIdx = -1;
     private int logAfLearningColIdx = -1;
     private int logAfCorrectionColIdx = -1;
-    private int logMafColIdx = -1;    
-    private int logFfbColIdx = -1;    
+    private int logMafColIdx = -1;
+    private int logFfbColIdx = -1;
     private int logSdColIdx = -1;
+    private TableColumn mafColumn = null;
     
     private String[] logColumns = new String[] { "RPM", "IAT", "MP", "FFB", "AFR", "WB", "AFRE", "MAF", "VE", "CL" };
     private JComboBox<String> sdType = null;
@@ -130,6 +134,9 @@ public class VECalc extends ACompCalc {
         y3dAxisName = "RPM";
         z3dAxisName = "Avg Error %";
         initialize(logColumns);
+        mafColumn = logDataTable.getColumnModel().getColumn(7);
+        mafColumn.setIdentifier("MAF");
+        updateMafColumnVisibility();
     }
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -165,6 +172,7 @@ public class VECalc extends ACompCalc {
         mpType = addComboBox(cntlPanel, 7, new String [] { "Torr/mmHG Abs", "Torr/mmHG Rel Sea Lvl", "Psi Abs", "Psi Rel Sea Lvl" });
         addLabel(cntlPanel, 8, "Run");
         dataType = addComboBox(cntlPanel, 9, new String [] { "MAF Builder", "AFR Tuner" });
+        dataType.addItemListener(e -> { if (e.getStateChange() == ItemEvent.SELECTED) updateMafColumnVisibility(); });
         addCheckBox(cntlPanel, 10, "Hide Log Table", "hidelogtable");
         compareTableCheckBox = addCheckBox(cntlPanel, 11, "Compare Tables", "comparetables");
         addButton(cntlPanel, 12, "GO", "go", GridBagConstraints.EAST);
@@ -342,7 +350,8 @@ public class VECalc extends ACompCalc {
         if (logAfLearningColIdx == -1 && !fullTimeOl)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
         if (logAfCorrectionColIdx == -1 && !fullTimeOl){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
         if (logRpmColIdx == -1)                  { Config.setRpmColumnName(Config.NO_NAME);              ret = false; }
-        if (logMafColIdx == -1)                  { Config.setMassAirflowColumnName(Config.NO_NAME);      ret = false; }
+        boolean mafMode = (dataType.getSelectedIndex() == 0);
+        if (logMafColIdx == -1) { Config.setMassAirflowColumnName(Config.NO_NAME); if (mafMode) ret = false; }
         if (logMpColIdx == -1)                   { Config.setMpColumnName(Config.NO_NAME);               ret = false; }
         if (logIatColIdx == -1)                  { Config.setIatColumnName(Config.NO_NAME);              ret = false; }
         rpmMin = Config.getVERPMMinimumValue();
@@ -382,9 +391,10 @@ public class VECalc extends ACompCalc {
                     continue;
                 getColumnsFilters(elements);
                 boolean resetColumns = false;
+                boolean mafMode = (dataType.getSelectedIndex() == 0);
                 if (logThrottleAngleColIdx >= 0 || logFfbColIdx >= 0 || logSdColIdx >= 0 ||
                     logWbAfrColIdx >= 0 || logStockAfrColIdx >= 0 || logAfLearningColIdx >= 0 || logAfCorrectionColIdx >= 0 ||
-                    logRpmColIdx >= 0 || logMafColIdx >= 0 || logIatColIdx >= 0 || logMpColIdx >= 0) {
+                    logRpmColIdx >= 0 || (mafMode && logMafColIdx >= 0) || logIatColIdx >= 0 || logMpColIdx >= 0) {
                     if (displayDialog) {
                         int rc = JOptionPane.showOptionDialog(null, "Would you like to reset column names or filter values?", "Columns/Filters Reset", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, optionButtons, optionButtons[0]);
                         if (rc == 0)
@@ -396,8 +406,8 @@ public class VECalc extends ACompCalc {
 
                 if (resetColumns || logThrottleAngleColIdx < 0 || logFfbColIdx < 0 || logSdColIdx < 0 || logWbAfrColIdx < 0 ||
                     logStockAfrColIdx < 0 || logAfLearningColIdx < 0 || logAfCorrectionColIdx < 0 ||
-                    logRpmColIdx < 0 || logMafColIdx < 0 || logIatColIdx < 0 || logMpColIdx < 0) {
-                    ColumnsFiltersSelection selectionWindow = new VEColumnsFiltersSelection();
+                    logRpmColIdx < 0 || (mafMode && logMafColIdx < 0) || logIatColIdx < 0 || logMpColIdx < 0) {
+                    ColumnsFiltersSelection selectionWindow = new VEColumnsFiltersSelection(mafMode);
                     if (!selectionWindow.getUserSettings(elements) || !getColumnsFilters(elements))
                         return;
                 }
@@ -494,9 +504,10 @@ public class VECalc extends ACompCalc {
                                     logDataTable.setValueAt(afrStock, row, 4);
                                     logDataTable.setValueAt(afrWb, row, 5);
                                     logDataTable.setValueAt(afrEff, row, 6);
-                                    logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 7);
-                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, 8);
-                                    logDataTable.setValueAt(isClosed ? 1 : 0, row, 9);
+                                    if (mafMode)
+                                        logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 7);
+                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, mafMode ? 8 : 7);
+                                    logDataTable.setValueAt(isClosed ? 1 : 0, row, mafMode ? 9 : 8);
                                     row += 1;
                                 }
                                 else
@@ -552,16 +563,17 @@ public class VECalc extends ACompCalc {
             xData = new HashMap<Double, HashMap<Double, ArrayList<LogData>>>();
             HashMap<Double, ArrayList<LogData>> yData;
             ArrayList<LogData> data;
+            boolean mafMode = (dataType.getSelectedIndex() == 0);
             for (int i = 0; i < logDataTable.getRowCount(); ++i) {
                 rpmStr = logDataTable.getValueAt(i, 0).toString();
                 iatStr = logDataTable.getValueAt(i, 1).toString();
                 mpStr  = logDataTable.getValueAt(i, 2).toString();
                 ffbStr = logDataTable.getValueAt(i, 3).toString();
                 afreStr = logDataTable.getValueAt(i, 6).toString();
-                mafStr = logDataTable.getValueAt(i, 7).toString();
-                sdStr  = logDataTable.getValueAt(i, 8).toString();
-                clStr  = logDataTable.getValueAt(i, 9).toString();
-                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afreStr.isEmpty() || mafStr.isEmpty() || ffbStr.isEmpty() || sdStr.isEmpty())
+                mafStr = mafMode ? logDataTable.getValueAt(i, 7).toString() : "";
+                sdStr  = logDataTable.getValueAt(i, mafMode ? 8 : 7).toString();
+                clStr  = logDataTable.getValueAt(i, mafMode ? 9 : 8).toString();
+                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afreStr.isEmpty() || (mafMode && mafStr.isEmpty()) || ffbStr.isEmpty() || sdStr.isEmpty())
                     continue;
                 logData = new LogData();
                 logData.mp = (Double.valueOf(mpStr) * mapG) + mapO;
@@ -573,8 +585,13 @@ public class VECalc extends ACompCalc {
                 logData.mp = xAxisArray.get(Utils.closestValueIndex(logData.mp, xAxisArray));
                 logData.rpm = yAxisArray.get(Utils.closestValueIndex(logData.rpm, yAxisArray));
                 logData.iat = Double.valueOf(iatStr);
-                logData.maf = Double.valueOf(mafStr);
-                logData.sd = Double.valueOf(sdStr);
+                if (mafMode) {
+                    logData.maf = Double.valueOf(mafStr);
+                    logData.sd = Double.valueOf(sdStr);
+                } else {
+                    logData.maf = Double.NaN;
+                    logData.sd = Double.valueOf(sdStr);
+                }
                 logData.afr = Double.valueOf(afreStr);
                 try {
                     logData.cl = Integer.parseInt(clStr);
@@ -582,7 +599,10 @@ public class VECalc extends ACompCalc {
                     logData.cl = 0;
                 }
                 logData.ffb = Double.valueOf(ffbStr);
-                logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
+                if (mafMode)
+                    logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
+                else
+                    logData.sderr = 0.0;
                 if (Double.isNaN(trims.get(i)))
                     logData.afrerr = ((logData.afr - logData.ffb) / logData.ffb) * 100.0;
                 else
@@ -682,6 +702,26 @@ public class VECalc extends ACompCalc {
         trims.clear();
         runData.clear();
         trendData.clear();
+    }
+
+    private void updateMafColumnVisibility() {
+        if (mafColumn == null || logDataTable == null)
+            return;
+        boolean isMafMode = (dataType.getSelectedIndex() == 0);
+        TableColumnModel model = logDataTable.getColumnModel();
+        boolean hasColumn;
+        try {
+            model.getColumnIndex(mafColumn.getIdentifier());
+            hasColumn = true;
+        } catch (IllegalArgumentException ex) {
+            hasColumn = false;
+        }
+        if (isMafMode && !hasColumn) {
+            model.addColumn(mafColumn);
+            model.moveColumn(model.getColumnCount() - 1, 7);
+        } else if (!isMafMode && hasColumn) {
+            model.removeColumn(mafColumn);
+        }
     }
     
     protected void clearLogDataTables() {

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -93,6 +93,9 @@ public class VECalc extends ACompCalc {
     private double iatMax = Config.getVEIatMaximumValue();
     private int corrApplied = Config.getVECorrectionAppliedValue();
     private boolean fullTimeOl = Config.veFullTimeOl();
+    private double afrSwitchMp = Config.getVEWbAfrMpSwitch();
+    private int afrSwitchRpm = Config.getVEWbAfrRpmSwitch();
+    private double afrSmooth = Config.getVEWbAfrSmooth();
     private int logClOlStatusColIdx = -1;
     private int logThrottleAngleColIdx = -1;
     private int logRpmColIdx = -1;
@@ -326,6 +329,7 @@ public class VECalc extends ACompCalc {
         logIatColIdx = columns.indexOf(logIatColName);
         logMpColIdx = columns.indexOf(logMpColName);
         fullTimeOl = Config.veFullTimeOl();
+        if (logClOlStatusColIdx == -1 && !fullTimeOl) { Config.setClOlStatusColumnName(Config.NO_NAME); ret = false; }
         if (logThrottleAngleColIdx == -1)        { Config.setThrottleAngleColumnName(Config.NO_NAME);    ret = false; }
         if (logFfbColIdx == -1)                  { Config.setFinalFuelingBaseColumnName(Config.NO_NAME); ret = false; }
         if (logSdColIdx == -1)                   { Config.setVEFlowColumnName(Config.NO_NAME);           ret = false; }
@@ -350,6 +354,9 @@ public class VECalc extends ACompCalc {
         afrMin = Config.getVEAfrMinimumValue();
         afrRowOffset = Config.getWBO2RowOffset();
         corrApplied = Config.getVECorrectionAppliedValue();
+        afrSwitchMp = Config.getVEWbAfrMpSwitch();
+        afrSwitchRpm = Config.getVEWbAfrRpmSwitch();
+        afrSmooth = Config.getVEWbAfrSmooth();
         return ret;
     }
     
@@ -433,17 +440,33 @@ public class VECalc extends ACompCalc {
                                 rpm = Double.valueOf(flds[logRpmColIdx]);
                                 ffb = Double.valueOf(flds[logFfbColIdx]);
                                 iat = Double.valueOf(flds[logIatColIdx]);
-                                if (flds[logClOlStatusColIdx] == "on")
-                                    clol = 0;
-                                else if (flds[logClOlStatusColIdx] == "off")
-                                    clol = 1;
-                                else
-                                    clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
-                                boolean isClosed = (clol == 0);
-                                if (isClosed) {
-                                    afr = Double.valueOf(afrflds[logStockAfrColIdx]);
+                                boolean isClosed = false;
+                                if (!fullTimeOl) {
+                                    if (flds[logClOlStatusColIdx] == "on")
+                                        clol = 0;
+                                    else if (flds[logClOlStatusColIdx] == "off")
+                                        clol = 1;
+                                    else
+                                        clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                    isClosed = (clol == 0);
+                                    afr = isClosed ? Double.valueOf(afrflds[logStockAfrColIdx]) : Double.valueOf(afrflds[logWbAfrColIdx]);
                                 } else {
-                                    afr = Double.valueOf(afrflds[logWbAfrColIdx]);
+                                    double mp = Double.valueOf(flds[logMpColIdx]);
+                                    double afrWb = Double.valueOf(afrflds[logWbAfrColIdx]);
+                                    double afrStock = Double.valueOf(afrflds[logStockAfrColIdx]);
+                                    double alpha;
+                                    if (afrSmooth <= 0)
+                                        alpha = (rpm >= afrSwitchRpm || mp >= afrSwitchMp) ? 1.0 : 0.0;
+                                    else {
+                                        double mpA = 0.5 + 0.5 * Math.tanh((mp - afrSwitchMp) / afrSmooth);
+                                        double rpmA = 0.5 + 0.5 * Math.tanh((rpm - afrSwitchRpm) / afrSmooth);
+                                        alpha = Math.max(mpA, rpmA);
+                                    }
+                                    if (alpha < 0)
+                                        alpha = 0;
+                                    else if (alpha > 1)
+                                        alpha = 1;
+                                    afr = afrStock * (1 - alpha) + afrWb * alpha;
                                 }
                                 boolean flag = isClosed ? (afrMin <= afr && afr <= afrMaxCl) : ((afr <= afrMaxOl || throttle >= thrtlMin) && afr <= afrMaxOl);
                                 if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -79,19 +79,18 @@ public class VECalc extends ACompCalc {
 
     private static final String xAxisName = "RPM";
     private static final String yAxisName = "Estimated VE";
-    private int clValue = Config.getVEClOlStatusValue();
     private int afrRowOffset = Config.getWBO2RowOffset();
     private int thrtlMaxChange = Config.getVEThrottleChangeMaxValue();
     private int minCellHitCount = Config.getVEMinCellHitCount();
     private double thrtlMin = Config.getVEThrottleMinimumValue();
-    private double afrMax = Config.getVEOlAfrMaximumValue();
+    private double afrMaxOl = Config.getVEOlAfrMaximumValue();
+    private double afrMaxCl = Config.getVEClAfrMaximumValue();
     private double afrMin = Config.getVEAfrMinimumValue();
     private double rpmMin = Config.getVERPMMinimumValue();
     private double ffbMax = Config.getFFBMaximumValue();
     private double ffbMin = Config.getFFBMinimumValue();
     private double mpMin = Config.getVEMPMinimumValue();
     private double iatMax = Config.getVEIatMaximumValue();
-    private boolean isOl = Config.veOpenLoop();
     private int corrApplied = Config.getVECorrectionAppliedValue();
     private int logClOlStatusColIdx = -1;
     private int logThrottleAngleColIdx = -1;
@@ -313,7 +312,6 @@ public class VECalc extends ACompCalc {
         String logMafColName = Config.getMassAirflowColumnName();
         String logIatColName = Config.getIatColumnName();
         String logMpColName = Config.getMpColumnName();
-        isOl = Config.veOpenLoop();
         logClOlStatusColIdx = columns.indexOf(logClOlStatusColName);
         logThrottleAngleColIdx = columns.indexOf(logThrottleAngleColName);
         logFfbColIdx = columns.indexOf(logFfbColName);
@@ -329,15 +327,14 @@ public class VECalc extends ACompCalc {
         if (logThrottleAngleColIdx == -1)        { Config.setThrottleAngleColumnName(Config.NO_NAME);    ret = false; }
         if (logFfbColIdx == -1)                  { Config.setFinalFuelingBaseColumnName(Config.NO_NAME); ret = false; }
         if (logSdColIdx == -1)                   { Config.setVEFlowColumnName(Config.NO_NAME);           ret = false; }
-        if (logWbAfrColIdx == -1 && isOl)        { Config.setWidebandAfrColumnName(Config.NO_NAME);      ret = false; }
-        if (logStockAfrColIdx == -1 && !isOl)    { Config.setAfrColumnName(Config.NO_NAME);              ret = false; }
-        if (logAfLearningColIdx == -1 && !isOl)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
-        if (logAfCorrectionColIdx == -1 && !isOl){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
+        if (logWbAfrColIdx == -1)        { Config.setWidebandAfrColumnName(Config.NO_NAME);      ret = false; }
+        if (logStockAfrColIdx == -1)    { Config.setAfrColumnName(Config.NO_NAME);              ret = false; }
+        if (logAfLearningColIdx == -1)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
+        if (logAfCorrectionColIdx == -1){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
         if (logRpmColIdx == -1)                  { Config.setRpmColumnName(Config.NO_NAME);              ret = false; }
         if (logMafColIdx == -1)                  { Config.setMassAirflowColumnName(Config.NO_NAME);      ret = false; }
         if (logMpColIdx == -1)                   { Config.setMpColumnName(Config.NO_NAME);               ret = false; }
         if (logIatColIdx == -1)                  { Config.setIatColumnName(Config.NO_NAME);              ret = false; }
-        clValue = Config.getVEClOlStatusValue();
         rpmMin = Config.getVERPMMinimumValue();
         mpMin = Config.getVEMPMinimumValue();
         iatMax = Config.getVEIatMaximumValue();
@@ -346,7 +343,8 @@ public class VECalc extends ACompCalc {
         thrtlMaxChange = Config.getVEThrottleChangeMaxValue();
         minCellHitCount = Config.getVEMinCellHitCount();
         thrtlMin = Config.getVEThrottleMinimumValue();
-        afrMax = (isOl ? Config.getVEOlAfrMaximumValue() : Config.getVEClAfrMaximumValue());
+        afrMaxOl = Config.getVEOlAfrMaximumValue();
+        afrMaxCl = Config.getVEClAfrMaximumValue();
         afrMin = Config.getVEAfrMinimumValue();
         afrRowOffset = Config.getWBO2RowOffset();
         corrApplied = Config.getVECorrectionAppliedValue();
@@ -370,8 +368,8 @@ public class VECalc extends ACompCalc {
                     continue;
                 getColumnsFilters(elements);
                 boolean resetColumns = false;
-                if (logThrottleAngleColIdx >= 0 || logFfbColIdx >= 0 || logSdColIdx >= 0 || (logWbAfrColIdx >= 0 && isOl) ||
-                    (logStockAfrColIdx >= 0 && !isOl) || (logAfLearningColIdx >= 0 && !isOl) || (logAfCorrectionColIdx >= 0 && !isOl) ||
+                if (logThrottleAngleColIdx >= 0 || logFfbColIdx >= 0 || logSdColIdx >= 0 ||
+                    logWbAfrColIdx >= 0 || logStockAfrColIdx >= 0 || logAfLearningColIdx >= 0 || logAfCorrectionColIdx >= 0 ||
                     logRpmColIdx >= 0 || logMafColIdx >= 0 || logIatColIdx >= 0 || logMpColIdx >= 0) {
                     if (displayDialog) {
                         int rc = JOptionPane.showOptionDialog(null, "Would you like to reset column names or filter values?", "Columns/Filters Reset", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, optionButtons, optionButtons[0]);
@@ -382,16 +380,14 @@ public class VECalc extends ACompCalc {
                     }
                 }
 
-                if (resetColumns || logThrottleAngleColIdx < 0 || logFfbColIdx < 0 || logSdColIdx < 0 || (logWbAfrColIdx < 0 && isOl) ||
-                    (logStockAfrColIdx < 0 && !isOl) || (logAfLearningColIdx < 0 && !isOl) || (logAfCorrectionColIdx < 0 && !isOl) ||
+                if (resetColumns || logThrottleAngleColIdx < 0 || logFfbColIdx < 0 || logSdColIdx < 0 || logWbAfrColIdx < 0 ||
+                    logStockAfrColIdx < 0 || logAfLearningColIdx < 0 || logAfCorrectionColIdx < 0 ||
                     logRpmColIdx < 0 || logMafColIdx < 0 || logIatColIdx < 0 || logMpColIdx < 0) {
                     ColumnsFiltersSelection selectionWindow = new VEColumnsFiltersSelection();
                     if (!selectionWindow.getUserSettings(elements) || !getColumnsFilters(elements))
                         return;
                 }
                 
-                if (logClOlStatusColIdx == -1)
-                    clValue = -1;
                 
                 String[] flds;
                 String[] afrflds;
@@ -432,24 +428,28 @@ public class VECalc extends ACompCalc {
                             }
                             else if (row <= 0 || Math.abs(ppThrottle - throttle) <= thrtlMaxChange2) {
                                 // Filters
-                                afr = (isOl ? Double.valueOf(afrflds[logWbAfrColIdx]) : Double.valueOf(afrflds[logStockAfrColIdx]));
                                 rpm = Double.valueOf(flds[logRpmColIdx]);
                                 ffb = Double.valueOf(flds[logFfbColIdx]);
                                 iat = Double.valueOf(flds[logIatColIdx]);
-                                if (clValue != -1)
-                                {
-                                    if (flds[logClOlStatusColIdx] == "on")
-                                        clol = 0;
-                                    else if (flds[logClOlStatusColIdx] == "off")
-                                        clol = 1;
-                                    else
-                                        clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                if (flds[logClOlStatusColIdx] == "on")
+                                    clol = 0;
+                                else if (flds[logClOlStatusColIdx] == "off")
+                                    clol = 1;
+                                else
+                                    clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                boolean isClosed = (clol == 0);
+                                if (isClosed) {
+                                    afr = Double.valueOf(afrflds[logStockAfrColIdx]);
+                                } else {
+                                    afr = Double.valueOf(afrflds[logWbAfrColIdx]);
                                 }
-                                boolean flag = isOl ? ((afr <= afrMax || throttle >= thrtlMin) && afr <= afrMax) : (afrMin <= afr);
-                                if (flag && clol == clValue && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
+                                boolean flag = isClosed ? (afrMin <= afr && afr <= afrMaxCl) : ((afr <= afrMaxOl || throttle >= thrtlMin) && afr <= afrMaxOl);
+                                if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
                                     removed = false;
-                                    if (!isOl)
+                                    if (isClosed)
                                         trims.add(Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]));
+                                    else
+                                        trims.add(Double.NaN);
                                     Utils.ensureRowCount(row + 1, logDataTable);
                                     logDataTable.setValueAt(rpm, row, 0);
                                     logDataTable.setValueAt(iat, row, 1);
@@ -538,10 +538,10 @@ public class VECalc extends ACompCalc {
                 logData.afr = Double.valueOf(afrStr);
                 logData.ffb = Double.valueOf(ffbStr);
                 logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
-                if (isOl)
+                if (Double.isNaN(trims.get(i)))
                     logData.afrerr = ((logData.afr - logData.ffb) / logData.ffb) * 100.0;
                 else
-                    logData.afrerr = trims.get(i);// + ((14.7 - logData.ffb) / 14.7 * 100);
+                    logData.afrerr = trims.get(i);
                 
                 yData = xData.get(logData.mp);
                 if (yData == null) {

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -27,6 +27,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
+import javax.swing.JFormattedTextField;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -38,6 +38,10 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     JPanel selectionPanel = null;
     private String[] columns = null;
     private boolean isFullOl = false;
+    private JFormattedTextField maxAfrWbFilter = null;
+    private JFormattedTextField minAfrWbFilter = null;
+    private JFormattedTextField maxAfrClFilter = null;
+    private JFormattedTextField minAfrClFilter = null;
     
     public boolean getUserSettings(String[] cols) {
         columns = cols;
@@ -111,10 +115,14 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         thrtlChangeMaxFilter.setValue(Config.getVEThrottleChangeMaxValue());
         addThrottleMinimumFilter();
         thrtlMinimumFilter.setValue(Config.getVEThrottleMinimumValue());
-        addAFRMaximumFilter();
-        maxAfrFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
-        addAFRMinimumFilter();
-        minAfrFilter.setText(String.valueOf(Config.getVEAfrMinimumValue()));
+        addWbAFRMaximumFilter();
+        maxAfrWbFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
+        addWbAFRMinimumFilter();
+        minAfrWbFilter.setText(String.valueOf(Config.getVEOlAfrMinimumValue()));
+        addStockAFRMaximumFilter();
+        maxAfrClFilter.setText(String.valueOf(Config.getVEClAfrMaximumValue()));
+        addStockAFRMinimumFilter();
+        minAfrClFilter.setText(String.valueOf(Config.getVEClAfrMinimumValue()));
         if (!isFullOl) {
             addCLOLStatusFilter();
             clolStatusFilter.setValue(Config.getVEClOlStatusValue());
@@ -295,11 +303,11 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         // Throttle Minimum Input
         Config.setVEThrottleMinimumValue(Integer.valueOf(thrtlMinimumFilter.getText()));
 
-        // AFR Maximum
-        Config.setVEOlAfrMaximumValue(Double.valueOf(maxAfrFilter.getText()));
-
-        // AFR Minimum
-        Config.setVEAfrMinimumValue(Double.valueOf(minAfrFilter.getText()));
+        // AFR filters
+        Config.setVEOlAfrMaximumValue(Double.valueOf(maxAfrWbFilter.getText()));
+        Config.setVEOlAfrMinimumValue(Double.valueOf(minAfrWbFilter.getText()));
+        Config.setVEClAfrMaximumValue(Double.valueOf(maxAfrClFilter.getText()));
+        Config.setVEClAfrMinimumValue(Double.valueOf(minAfrClFilter.getText()));
 
         // WBO2 Row Offset
         Config.setWBO2RowOffset(Integer.valueOf(wbo2RowOffsetField.getText()));
@@ -336,6 +344,34 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
 
         return ret;
     }
+
+    private void addWbAFRMaximumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where WB AFR is above the specified maximum");
+        addLabel(filtersPanel, ++filtrow, "WB AFR Maximum");
+        maxAfrWbFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "maxafrwb");
+    }
+
+    private void addWbAFRMinimumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where WB AFR is below the specified minimum");
+        addLabel(filtersPanel, ++filtrow, "WB AFR Minimum");
+        minAfrWbFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "minafrwb");
+    }
+
+    private void addStockAFRMaximumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where Stock AFR is above the specified maximum");
+        addLabel(filtersPanel, ++filtrow, "Stock AFR Maximum");
+        maxAfrClFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "maxafrstock");
+    }
+
+    private void addStockAFRMinimumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where Stock AFR is below the specified minimum");
+        addLabel(filtersPanel, ++filtrow, "Stock AFR Minimum");
+        minAfrClFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "minafrstock");
+    }
     
     protected boolean processDefaultButton(ActionEvent e) {
         if ("thrtlchange".equals(e.getActionCommand()))
@@ -354,10 +390,14 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
             clolStatusFilter.setValue(Integer.valueOf(Config.DefaultClOlStatusValue));
         else if ("minthrtl".equals(e.getActionCommand()))
             thrtlMinimumFilter.setValue(Integer.valueOf(Config.DefaultVEThrottleMinimum));
-        else if ("maxafr".equals(e.getActionCommand()))
-            maxAfrFilter.setText(Config.DefaultVEOlAfrMaximum);
-        else if ("minafr".equals(e.getActionCommand()))
-            minAfrFilter.setText(Config.DefaultVEAfrMinimum);
+        else if ("maxafrwb".equals(e.getActionCommand()))
+            maxAfrWbFilter.setText(Config.DefaultVEOlAfrMaximum);
+        else if ("minafrwb".equals(e.getActionCommand()))
+            minAfrWbFilter.setText(Config.DefaultVEOlAfrMinimum);
+        else if ("maxafrstock".equals(e.getActionCommand()))
+            maxAfrClFilter.setText(Config.DefaultVEClAfrMaximum);
+        else if ("minafrstock".equals(e.getActionCommand()))
+            minAfrClFilter.setText(Config.DefaultVEClAfrMinimum);
         else if ("wbo2offset".equals(e.getActionCommand()))
             wbo2RowOffsetField.setText(Config.DefaultWBO2RowOffset);
         else if ("wbswitchmp".equals(e.getActionCommand()))

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -21,8 +21,10 @@ package com.vgi.mafscaling;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JOptionPane;
@@ -35,12 +37,29 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     private JScrollPane pane = null;
     JPanel selectionPanel = null;
     private String[] columns = null;
+    private boolean isFullOl = false;
     
     public boolean getUserSettings(String[] cols) {
         columns = cols;
         createScrollPane();
+        final JComboBox<String> modeSelection = new JComboBox<String>(new String [] { "CL/OL", "Full Time OL" });
+        modeSelection.addItemListener(e -> {
+            if(e.getStateChange() == ItemEvent.SELECTED) {
+                isFullOl = (modeSelection.getSelectedIndex() == 1);
+                selectionPanel.remove(columnsPanel);
+                selectionPanel.remove(filtersPanel);
+                createColumnsPanel(columns);
+                createFiltersPanel();
+                selectionPanel.add(columnsPanel);
+                selectionPanel.add(filtersPanel);
+                selectionPanel.revalidate();
+                selectionPanel.repaint();
+                pane.setPreferredSize(new Dimension(windowWidth, windowHeight));
+                SwingUtilities.invokeLater(() -> pane.getVerticalScrollBar().setValue(0));
+            }
+        });
 
-        JComponent[] inputs = new JComponent[] {pane};
+        JComponent[] inputs = new JComponent[] {modeSelection, pane};
         // bring scroll pane to the start
         SwingUtilities.invokeLater(new Runnable() { public void run() { pane.getVerticalScrollBar().setValue(0); } });
         
@@ -72,8 +91,10 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     protected void addColSelection() {
         addWidebandAFRColSelection();
         addStockAFRColSelection();
-        addAFCorrectionColSelection();
-        addAFLearningColSelection();
+        if (!isFullOl) {
+            addAFCorrectionColSelection();
+            addAFLearningColSelection();
+        }
         addRPMColSelection();
         addIATColSelection();
         addThrottleAngleColSelection();
@@ -154,25 +175,27 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         else
             Config.setAfrColumnName(value);
 
-        // AFR Learning
-        value = afLearningName.getText().trim();
-        colName = afLearningLabelText;
-        if (value.isEmpty()) {
-            ret = false;
-            error.append("\"").append(colName).append("\" column must be specified\n");
-        }
-        else
-            Config.setAfLearningColumnName(value);
+        if (!isFullOl) {
+            // AFR Learning
+            value = afLearningName.getText().trim();
+            colName = afLearningLabelText;
+            if (value.isEmpty()) {
+                ret = false;
+                error.append("\"").append(colName).append("\" column must be specified\n");
+            }
+            else
+                Config.setAfLearningColumnName(value);
 
-        // AFR Correction
-        value = afCorrectionName.getText().trim();
-        colName = afCorrectionLabelText;
-        if (value.isEmpty()) {
-            ret = false;
-            error.append("\"").append(colName).append("\" column must be specified\n");
+            // AFR Correction
+            value = afCorrectionName.getText().trim();
+            colName = afCorrectionLabelText;
+            if (value.isEmpty()) {
+                ret = false;
+                error.append("\"").append(colName).append("\" column must be specified\n");
+            }
+            else
+                Config.setAfCorrectionColumnName(value);
         }
-        else
-            Config.setAfCorrectionColumnName(value);
         
         // Engine Speed
         value = rpmName.getText().trim();
@@ -290,7 +313,9 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         
         // Correction applied
         Config.setVECorrectionAppliedValue(Integer.valueOf(correctionAppliedValue.getValue().toString()));
-        
+
+        Config.veFullTimeOl(isFullOl);
+
         return ret;
     }
     

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -100,7 +100,8 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         addThrottleAngleColSelection();
         addManifoldPressureColSelection();
         addFFBColSelection();
-        addClOlStatusColSelection();
+        if (!isFullOl)
+            addClOlStatusColSelection();
         addMAFColSelection();
         addVEFlowColSelection();
     }
@@ -114,8 +115,17 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         maxAfrFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
         addAFRMinimumFilter();
         minAfrFilter.setText(String.valueOf(Config.getVEAfrMinimumValue()));
-        addCLOLStatusFilter();
-        clolStatusFilter.setValue(Config.getVEClOlStatusValue());
+        if (!isFullOl) {
+            addCLOLStatusFilter();
+            clolStatusFilter.setValue(Config.getVEClOlStatusValue());
+        } else {
+            addAfrMpSwitchFilter();
+            afrMpSwitchFilter.setText(String.valueOf(Config.getVEWbAfrMpSwitch()));
+            addAfrRpmSwitchFilter();
+            afrRpmSwitchFilter.setText(String.valueOf(Config.getVEWbAfrRpmSwitch()));
+            addAfrSmoothFilter();
+            afrSmoothFilter.setText(String.valueOf(Config.getVEWbAfrSmooth()));
+        }
         addIATMaximumFilter();
         maxIatFilter.setText(String.valueOf(Config.getVEIatMaximumValue()));
         addRPMMinimumFilter();
@@ -144,7 +154,7 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
                     label.setText(label.getText() + " (hint: check min RPM in SD table (y-axis)");
                 else if (label.getText().startsWith("Remove data where Manifold Pressure is below"))
                     label.setText(label.getText() + " (hint: check min MP in SD table (x-axis)");
-                else if (label.getText().equals(clolStatusLabelText))
+                else if (!isFullOl && label.getText().equals(clolStatusLabelText))
                     label.setText(clolStatusLabelText + " *");
             }
         }
@@ -247,15 +257,17 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         else
             Config.setFinalFuelingBaseColumnName(value);
 
-        // CL/OL Status
-        value = clolStatusName.getText().trim();
-        colName = clolStatusLabelText;
-        if (value.isEmpty()) {
-            ret = false;
-            error.append("\"").append(colName).append("\" column must be specified\n");
+        if (!isFullOl) {
+            // CL/OL Status
+            value = clolStatusName.getText().trim();
+            colName = clolStatusLabelText;
+            if (value.isEmpty()) {
+                ret = false;
+                error.append("\"").append(colName).append("\" column must be specified\n");
+            }
+            else
+                Config.setClOlStatusColumnName(value);
         }
-        else
-            Config.setClOlStatusColumnName(value);
 
         // MAF
         value = mafName.getText().trim();
@@ -291,9 +303,15 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
 
         // WBO2 Row Offset
         Config.setWBO2RowOffset(Integer.valueOf(wbo2RowOffsetField.getText()));
-        
-        // CL/OL Status
-        Config.setVEClOlStatusValue(Integer.valueOf(clolStatusFilter.getValue().toString()));
+
+        if (isFullOl) {
+            Config.setVEWbAfrMpSwitch(Double.valueOf(afrMpSwitchFilter.getText()));
+            Config.setVEWbAfrRpmSwitch(Integer.valueOf(afrRpmSwitchFilter.getText()));
+            Config.setVEWbAfrSmooth(Double.valueOf(afrSmoothFilter.getText()));
+        } else {
+            // CL/OL Status
+            Config.setVEClOlStatusValue(Integer.valueOf(clolStatusFilter.getValue().toString()));
+        }
         
         // IAT filter
         Config.setVEIatMaximumValue(Double.valueOf(maxIatFilter.getText()));
@@ -342,6 +360,12 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
             minAfrFilter.setText(Config.DefaultVEAfrMinimum);
         else if ("wbo2offset".equals(e.getActionCommand()))
             wbo2RowOffsetField.setText(Config.DefaultWBO2RowOffset);
+        else if ("wbswitchmp".equals(e.getActionCommand()))
+            afrMpSwitchFilter.setText(Config.DefaultVEWbAfrMpSwitch);
+        else if ("wbswitchrpm".equals(e.getActionCommand()))
+            afrRpmSwitchFilter.setText(Config.DefaultVEWbAfrRpmSwitch);
+        else if ("wbsmooth".equals(e.getActionCommand()))
+            afrSmoothFilter.setText(Config.DefaultVEWbAfrSmooth);
         else if ("minhitcnt".equals(e.getActionCommand()))
             minCellHitCountFilter.setText(Config.DefaultVEMinCellHitCount);
         else if ("corrapply".equals(e.getActionCommand()))

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -39,10 +39,19 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     JPanel selectionPanel = null;
     private String[] columns = null;
     private boolean isFullOl = false;
+    private boolean mafMode = true;
     private JFormattedTextField maxAfrWbFilter = null;
     private JFormattedTextField minAfrWbFilter = null;
     private JFormattedTextField maxAfrClFilter = null;
     private JFormattedTextField minAfrClFilter = null;
+
+    public VEColumnsFiltersSelection() {
+        this(true);
+    }
+
+    public VEColumnsFiltersSelection(boolean mafMode) {
+        this.mafMode = mafMode;
+    }
     
     public boolean getUserSettings(String[] cols) {
         columns = cols;
@@ -107,7 +116,8 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         addFFBColSelection();
         if (!isFullOl)
             addClOlStatusColSelection();
-        addMAFColSelection();
+        if (mafMode)
+            addMAFColSelection();
         addVEFlowColSelection();
     }
     
@@ -278,15 +288,19 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
                 Config.setClOlStatusColumnName(value);
         }
 
-        // MAF
-        value = mafName.getText().trim();
-        colName = mafLabelText;
-        if (value.isEmpty()) {
-            ret = false;
-            error.append("\"").append(colName).append("\" column must be specified\n");
+        if (mafMode) {
+            // MAF
+            value = mafName.getText().trim();
+            colName = mafLabelText;
+            if (value.isEmpty()) {
+                ret = false;
+                error.append("\"").append(colName).append("\" column must be specified\n");
+            }
+            else
+                Config.setMassAirflowColumnName(value);
+        } else {
+            Config.setMassAirflowColumnName(Config.NO_NAME);
         }
-        else
-            Config.setMassAirflowColumnName(value);
 
         // VE Flow
         value = veFlowName.getText().trim();

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -21,11 +21,8 @@ package com.vgi.mafscaling;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
-import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JOptionPane;
@@ -38,32 +35,12 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     private JScrollPane pane = null;
     JPanel selectionPanel = null;
     private String[] columns = null;
-    private boolean isOl = true;
     
     public boolean getUserSettings(String[] cols) {
         columns = cols;
         createScrollPane();
 
-        final JComboBox<String> clOlSelection = new JComboBox<String>(new String [] { "Open Loop", "Closed Loop" });
-        clOlSelection.addItemListener(new ItemListener() {
-            public void itemStateChanged(ItemEvent e) {
-                if(e.getStateChange() == ItemEvent.SELECTED) {
-                    isOl = (clOlSelection.getSelectedIndex() == 0? true: false);
-                    selectionPanel.remove(columnsPanel);
-                    selectionPanel.remove(filtersPanel);
-                    createColumnsPanel(columns);
-                    createFiltersPanel();
-                    selectionPanel.add(columnsPanel);
-                    selectionPanel.add(filtersPanel);
-                    selectionPanel.revalidate();
-                    selectionPanel.repaint();
-                    pane.setPreferredSize(new Dimension(windowWidth, windowHeight));
-                    SwingUtilities.invokeLater(new Runnable() { public void run() { pane.getVerticalScrollBar().setValue(0); } });
-                }
-            }
-        });
-        
-        JComponent[] inputs = new JComponent[] {clOlSelection, pane};
+        JComponent[] inputs = new JComponent[] {pane};
         // bring scroll pane to the start
         SwingUtilities.invokeLater(new Runnable() { public void run() { pane.getVerticalScrollBar().setValue(0); } });
         
@@ -93,14 +70,10 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     }
     
     protected void addColSelection() {
-        if (isOl) {
-            addWidebandAFRColSelection();
-        }
-        else {
-            addStockAFRColSelection();
-            addAFCorrectionColSelection();
-            addAFLearningColSelection();
-        }
+        addWidebandAFRColSelection();
+        addStockAFRColSelection();
+        addAFCorrectionColSelection();
+        addAFLearningColSelection();
         addRPMColSelection();
         addIATColSelection();
         addThrottleAngleColSelection();
@@ -114,18 +87,12 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     protected void addFilterSelection() {
         addThrottleChangeMaximumFilter();
         thrtlChangeMaxFilter.setValue(Config.getVEThrottleChangeMaxValue());
-        if (isOl) {
-            addThrottleMinimumFilter();
-            thrtlMinimumFilter.setValue(Config.getVEThrottleMinimumValue());
-            addAFRMaximumFilter();
-            maxAfrFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
-        }
-        else {
-            addAFRMaximumFilter();
-            maxAfrFilter.setText(String.valueOf(Config.getVEClAfrMaximumValue()));
-            addAFRMinimumFilter();
-            minAfrFilter.setText(String.valueOf(Config.getVEAfrMinimumValue()));
-        }
+        addThrottleMinimumFilter();
+        thrtlMinimumFilter.setValue(Config.getVEThrottleMinimumValue());
+        addAFRMaximumFilter();
+        maxAfrFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
+        addAFRMinimumFilter();
+        minAfrFilter.setText(String.valueOf(Config.getVEAfrMinimumValue()));
         addCLOLStatusFilter();
         clolStatusFilter.setValue(Config.getVEClOlStatusValue());
         addIATMaximumFilter();
@@ -138,10 +105,8 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         maxFFBFilter.setText(String.valueOf(Config.getFFBMaximumValue()));
         addFFBMinimumFilter();
         minFFBFilter.setText(String.valueOf(Config.getFFBMinimumValue()));
-        if (isOl) {
-            addWideBandAFRRowOffsetFilter();
-            wbo2RowOffsetField.setText(String.valueOf(Config.getWBO2RowOffset()));
-        }
+        addWideBandAFRRowOffsetFilter();
+        wbo2RowOffsetField.setText(String.valueOf(Config.getWBO2RowOffset()));
         addCellHitCountMinimumFilter();
         minCellHitCountFilter.setText(String.valueOf(Config.getVEMinCellHitCount()));
         addCorrectionAppliedValue();
@@ -152,7 +117,7 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
                 JEditorPane label = (JEditorPane)c;
                 if (label.getText().startsWith("Remove data where Throttle Input is below"))
                     label.setText(label.getText() + " (*** works with AFR Maximum filter)");
-                else if (isOl && label.getText().startsWith("Remove data where AFR is above"))
+                else if (label.getText().startsWith("Remove data where AFR is above"))
                     label.setText(label.getText() + "(*** works with Throttle Input Minimum filter)");
                 else if (label.getText().startsWith("Remove data where RPM is below"))
                     label.setText(label.getText() + " (hint: check min RPM in SD table (y-axis)");
@@ -169,51 +134,45 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         String value;
         String colName;
         
-        Config.veOpenLoop(isOl);
-
-        if (isOl) {
-            // Wideband AFR
-            value = wbAfrName.getText().trim();
-            colName = wbAfrLabelText;
-            if (value.isEmpty()) {
-                ret = false;
-                error.append("\"").append(colName).append("\" column must be specified\n");
-            }
-            else
-                Config.setWidebandAfrColumnName(value);
+        // Wideband AFR
+        value = wbAfrName.getText().trim();
+        colName = wbAfrLabelText;
+        if (value.isEmpty()) {
+            ret = false;
+            error.append("\"").append(colName).append("\" column must be specified\n");
         }
-        else {
-            // Stock AFR
-            value = stockAfrName.getText().trim();
-            colName = stockAfrLabelText;
-            if (value.isEmpty()) {
-                ret = false;
-                error.append("\"").append(colName).append("\" column must be specified\n");
-            }
-            else
-                Config.setAfrColumnName(value);
+        else
+            Config.setWidebandAfrColumnName(value);
 
-            // AFR Learning
-            value = afLearningName.getText().trim();
-            colName = afLearningLabelText;
-            if (value.isEmpty()) {
-                ret = false;
-                error.append("\"").append(colName).append("\" column must be specified\n");
-            }
-            else
-                Config.setAfLearningColumnName(value);
-            
-            // AFR Correction
-            value = afCorrectionName.getText().trim();
-            colName = afCorrectionLabelText;
-            if (value.isEmpty()) {
-                ret = false;
-                error.append("\"").append(colName).append("\" column must be specified\n");
-            }
-            else
-                Config.setAfCorrectionColumnName(value);
-            
+        // Stock AFR
+        value = stockAfrName.getText().trim();
+        colName = stockAfrLabelText;
+        if (value.isEmpty()) {
+            ret = false;
+            error.append("\"").append(colName).append("\" column must be specified\n");
         }
+        else
+            Config.setAfrColumnName(value);
+
+        // AFR Learning
+        value = afLearningName.getText().trim();
+        colName = afLearningLabelText;
+        if (value.isEmpty()) {
+            ret = false;
+            error.append("\"").append(colName).append("\" column must be specified\n");
+        }
+        else
+            Config.setAfLearningColumnName(value);
+
+        // AFR Correction
+        value = afCorrectionName.getText().trim();
+        colName = afCorrectionLabelText;
+        if (value.isEmpty()) {
+            ret = false;
+            error.append("\"").append(colName).append("\" column must be specified\n");
+        }
+        else
+            Config.setAfCorrectionColumnName(value);
         
         // Engine Speed
         value = rpmName.getText().trim();
@@ -298,23 +257,17 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         // Throttle Change % Maximum
         Config.setVEThrottleChangeMaxValue(Integer.valueOf(thrtlChangeMaxFilter.getValue().toString()));
 
-        if (isOl) {
-            // Throttle Minimum Input
-            Config.setVEThrottleMinimumValue(Integer.valueOf(thrtlMinimumFilter.getText()));
-            
-            // AFR Maximum
-            Config.setVEOlAfrMaximumValue(Double.valueOf(maxAfrFilter.getText()));
-            
-            // WBO2 Row Offset
-            Config.setWBO2RowOffset(Integer.valueOf(wbo2RowOffsetField.getText()));
-        }
-        else {
-            // AFR Maximum
-            Config.setVEClAfrMaximumValue(Double.valueOf(maxAfrFilter.getText()));
-            
-            // AFR Minimum
-            Config.setVEAfrMinimumValue(Double.valueOf(minAfrFilter.getText()));
-        }
+        // Throttle Minimum Input
+        Config.setVEThrottleMinimumValue(Integer.valueOf(thrtlMinimumFilter.getText()));
+
+        // AFR Maximum
+        Config.setVEOlAfrMaximumValue(Double.valueOf(maxAfrFilter.getText()));
+
+        // AFR Minimum
+        Config.setVEAfrMinimumValue(Double.valueOf(minAfrFilter.getText()));
+
+        // WBO2 Row Offset
+        Config.setWBO2RowOffset(Integer.valueOf(wbo2RowOffsetField.getText()));
         
         // CL/OL Status
         Config.setVEClOlStatusValue(Integer.valueOf(clolStatusFilter.getValue().toString()));
@@ -358,12 +311,8 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
             clolStatusFilter.setValue(Integer.valueOf(Config.DefaultClOlStatusValue));
         else if ("minthrtl".equals(e.getActionCommand()))
             thrtlMinimumFilter.setValue(Integer.valueOf(Config.DefaultVEThrottleMinimum));
-        else if ("maxafr".equals(e.getActionCommand())) {
-            if (isOl)
-                maxAfrFilter.setText(Config.DefaultVEOlAfrMaximum);
-            else
-                maxAfrFilter.setText(Config.DefaultVEClAfrMaximum);
-        }
+        else if ("maxafr".equals(e.getActionCommand()))
+            maxAfrFilter.setText(Config.DefaultVEOlAfrMaximum);
         else if ("minafr".equals(e.getActionCommand()))
             minAfrFilter.setText(Config.DefaultVEAfrMinimum);
         else if ("wbo2offset".equals(e.getActionCommand()))

--- a/src/com/vgi/mafscaling/VEPlusCalc.java
+++ b/src/com/vgi/mafscaling/VEPlusCalc.java
@@ -1,0 +1,792 @@
+/*
+* Open-Source tuning tools
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+package com.vgi.mafscaling;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Stroke;
+import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.text.DecimalFormat;
+import java.text.Format;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.ResourceBundle;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import org.apache.log4j.Logger;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.labels.StandardXYSeriesLabelGenerator;
+import org.jfree.chart.labels.StandardXYToolTipGenerator;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.chart.title.LegendTitle;
+import org.jfree.chart.ui.RectangleEdge;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import org.jfree.util.ShapeUtilities;
+
+public class VEPlusCalc extends ACompCalc {
+    private static final long serialVersionUID = -6288885401403089256L;
+    private static final Logger logger = Logger.getLogger(VEPlusCalc.class);
+    
+    class LogData {
+        public double rpm = 0;
+        public double mp = 0;
+        public double iat = 0;
+        public double afr = 0;
+        public double maf = 0;
+        public double ffb = 0;
+        public double sd = 0;
+        public double sderr = 0;
+        public double afrerr = 0;
+        public double afrStock = 0;
+        public double afrWb = 0;
+        public int cl = 0;
+    }
+
+    private static final String xAxisName = "RPM";
+    private static final String yAxisName = "Estimated VE";
+    private int afrRowOffset = Config.getWBO2RowOffset();
+    private int thrtlMaxChange = Config.getVEThrottleChangeMaxValue();
+    private int minCellHitCount = Config.getVEMinCellHitCount();
+    private double thrtlMin = Config.getVEThrottleMinimumValue();
+    private double afrMaxOl = Config.getVEOlAfrMaximumValue();
+    private double afrMaxCl = Config.getVEClAfrMaximumValue();
+    private double afrMinOl = Config.getVEOlAfrMinimumValue();
+    private double afrMinCl = Config.getVEClAfrMinimumValue();
+    private double rpmMin = Config.getVERPMMinimumValue();
+    private double ffbMax = Config.getFFBMaximumValue();
+    private double ffbMin = Config.getFFBMinimumValue();
+    private double mpMin = Config.getVEMPMinimumValue();
+    private double iatMax = Config.getVEIatMaximumValue();
+    private int corrApplied = Config.getVECorrectionAppliedValue();
+    private boolean fullTimeOl = Config.veFullTimeOl();
+    private double afrSwitchMp = Config.getVEWbAfrMpSwitch();
+    private int afrSwitchRpm = Config.getVEWbAfrRpmSwitch();
+    private double afrSmooth = Config.getVEWbAfrSmooth();
+    private int logClOlStatusColIdx = -1;
+    private int logThrottleAngleColIdx = -1;
+    private int logRpmColIdx = -1;
+    private int logMpColIdx = -1;
+    private int logIatColIdx = -1;
+    private int logWbAfrColIdx = -1;
+    private int logStockAfrColIdx = -1;
+    private int logAfLearningColIdx = -1;
+    private int logAfCorrectionColIdx = -1;
+    private int logMafColIdx = -1;
+    private int logFfbColIdx = -1;
+    private int logSdColIdx = -1;
+    private TableColumn mafColumn = null;
+    
+    private String[] logColumns = new String[] { "RPM", "IAT", "MP", "FFB", "AFR", "WB", "AFRE", "MAF", "VE", "CL" };
+    private JComboBox<String> sdType = null;
+    private JComboBox<String> mpType = null;
+    private JComboBox<String> dataType = null;
+    private ArrayList<Double> trims = new ArrayList<Double>();
+    private HashMap<Double, HashMap<Double, ArrayList<LogData>>> xData = null;
+
+    public VEPlusCalc(int tabPlacement) {
+        super(tabPlacement);
+        origTableName = "Current VE table";
+        newTableName = "New VE table";
+        corrTableName = "Error % table";
+        corrCountTableName = "Error % Count table";
+        x3dAxisName = "MP";
+        y3dAxisName = "RPM";
+        z3dAxisName = "Avg Error %";
+        initialize(logColumns);
+        mafColumn = logDataTable.getColumnModel().getColumn(7);
+        mafColumn.setIdentifier("MAF");
+        updateMafColumnVisibility();
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////
+    // DATA TAB
+    //////////////////////////////////////////////////////////////////////////////////////
+    
+    protected void createControlPanel(JPanel dataPanel) {
+        JPanel cntlPanel = new JPanel();
+        GridBagConstraints gbl_ctrlPanel = new GridBagConstraints();
+        gbl_ctrlPanel.insets = insets3;
+        gbl_ctrlPanel.anchor = GridBagConstraints.NORTH;
+        gbl_ctrlPanel.fill = GridBagConstraints.HORIZONTAL;
+        gbl_ctrlPanel.gridx = 0;
+        gbl_ctrlPanel.gridy = 0;
+        gbl_ctrlPanel.weightx = 1.0;
+        gbl_ctrlPanel.gridwidth = 2;
+        dataPanel.add(cntlPanel, gbl_ctrlPanel);
+        
+        GridBagLayout gbl_cntlPanel = new GridBagLayout();
+        gbl_cntlPanel.columnWidths = new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        gbl_cntlPanel.rowHeights = new int[]{0};
+        gbl_cntlPanel.columnWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0};
+        gbl_cntlPanel.rowWeights = new double[]{0};
+        cntlPanel.setLayout(gbl_cntlPanel);
+
+        addButton(cntlPanel, 0, "Load Log", "loadlog", GridBagConstraints.WEST);
+        addButton(cntlPanel, 1, "Clear SD Data", "clearorig", GridBagConstraints.WEST);
+        addButton(cntlPanel, 2, "Clear Run Data", "clearlog", GridBagConstraints.WEST);
+        addButton(cntlPanel, 3, "Clear All", "clearall", GridBagConstraints.WEST);
+        addLabel(cntlPanel, 4, "SD");
+        sdType = addComboBox(cntlPanel, 5, new String [] { "RR SD", "Cobb SD" });
+        addLabel(cntlPanel, 6, "MP");
+        mpType = addComboBox(cntlPanel, 7, new String [] { "Torr/mmHG Abs", "Torr/mmHG Rel Sea Lvl", "Psi Abs", "Psi Rel Sea Lvl" });
+        addLabel(cntlPanel, 8, "Run");
+        dataType = addComboBox(cntlPanel, 9, new String [] { "MAF Builder", "AFR Tuner" });
+        dataType.addItemListener(e -> { if (e.getStateChange() == ItemEvent.SELECTED) updateMafColumnVisibility(); });
+        addCheckBox(cntlPanel, 10, "Hide Log Table", "hidelogtable");
+        compareTableCheckBox = addCheckBox(cntlPanel, 11, "Compare Tables", "comparetables");
+        addButton(cntlPanel, 12, "GO", "go", GridBagConstraints.EAST);
+    }
+    
+    protected void formatTable(JTable table) {
+        if (table == corrCountTable) {
+            Format[][] formatMatrix = { { new DecimalFormat("#"), new DecimalFormat("0.00") }, { new DecimalFormat("#"), new DecimalFormat("#") } };
+            NumberFormatRenderer renderer = (NumberFormatRenderer)table.getDefaultRenderer(Object.class);
+            renderer.setFormats(formatMatrix);
+        }
+        else {
+            Format[][] formatMatrix = { { new DecimalFormat("#"), new DecimalFormat("0.00") } };
+            NumberFormatRenderer renderer = (NumberFormatRenderer)table.getDefaultRenderer(Object.class);
+            renderer.setFormats(formatMatrix);
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////
+    // CREATE CHART TAB
+    //////////////////////////////////////////////////////////////////////////////////////
+    
+    protected void createGraphTab() {
+        JPanel plotPanel = new JPanel();
+        add(plotPanel, "<html><div style='text-align: center;'>C<br>h<br>a<br>r<br>t</div></html>");
+
+        GridBagLayout gbl_plotPanel = new GridBagLayout();
+        gbl_plotPanel.columnWidths = new int[] {0};
+        gbl_plotPanel.rowHeights = new int[] {0, 0};
+        gbl_plotPanel.columnWeights = new double[]{1.0};
+        gbl_plotPanel.rowWeights = new double[]{0.0, 1.0};
+        plotPanel.setLayout(gbl_plotPanel);
+
+        JPanel cntlPanel = new JPanel();
+        GridBagConstraints gbl_ctrlPanel = new GridBagConstraints();
+        gbl_ctrlPanel.insets = new Insets(3, 3, 3, 3);
+        gbl_ctrlPanel.anchor = GridBagConstraints.NORTH;
+        gbl_ctrlPanel.weightx = 1.0;
+        gbl_ctrlPanel.fill = GridBagConstraints.HORIZONTAL;
+        gbl_ctrlPanel.gridx = 0;
+        gbl_ctrlPanel.gridy = 0;
+        plotPanel.add(cntlPanel, gbl_ctrlPanel);
+        
+        GridBagLayout gbl_cntlPanel = new GridBagLayout();
+        gbl_cntlPanel.columnWidths = new int[]{0, 0};
+        gbl_cntlPanel.rowHeights = new int[]{0, 0};
+        gbl_cntlPanel.columnWeights = new double[]{0.0, 1.0};
+        gbl_cntlPanel.rowWeights = new double[]{0};
+        cntlPanel.setLayout(gbl_cntlPanel);
+        
+        createChart(plotPanel, xAxisName, yAxisName);
+    }
+        
+
+    protected void createChart(JPanel plotPanel, String xAxisName, String yAxisName) {
+        JFreeChart chart = ChartFactory.createScatterPlot(null, null, null, null, PlotOrientation.VERTICAL, false, true, false);
+        chart.setBorderVisible(true);
+
+        chartPanel = new ChartPanel(chart, true, true, true, true, true);
+        chartPanel.setAutoscrolls(true);
+        chartPanel.setMouseWheelEnabled(true);
+        chartPanel.restoreAutoBounds();
+        chartPanel.setZoomInFactor(0.8);
+        chartPanel.setZoomOutFactor(1.2);
+        chartPanel.setZoomAroundAnchor(true);
+        chartPanel.setDomainZoomable(true);
+        chartPanel.setRangeZoomable(true);
+        
+        GridBagConstraints gbl_chartPanel = new GridBagConstraints();
+        gbl_chartPanel.anchor = GridBagConstraints.CENTER;
+        gbl_chartPanel.insets = new Insets(3, 3, 3, 3);
+        gbl_chartPanel.weightx = 1.0;
+        gbl_chartPanel.weighty = 1.0;
+        gbl_chartPanel.fill = GridBagConstraints.BOTH;
+        gbl_chartPanel.gridx = 0;
+        gbl_chartPanel.gridy = 1;
+        plotPanel.add(chartPanel, gbl_chartPanel);
+
+        XYLineAndShapeRenderer lineRenderer = new XYLineAndShapeRenderer();
+        lineRenderer.setUseFillPaint(true);
+        lineRenderer.setDefaultToolTipGenerator(new StandardXYToolTipGenerator( 
+                StandardXYToolTipGenerator.DEFAULT_TOOL_TIP_FORMAT, 
+                new DecimalFormat("0.00"), new DecimalFormat("0.00")));
+        
+        Stroke stroke = new BasicStroke(2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND, 1.0f, null, 0.0f);
+        lineRenderer.setSeriesStroke(0, stroke);
+        lineRenderer.setSeriesPaint(0, Color.RED);
+        lineRenderer.setSeriesShape(0, ShapeUtilities.createDiamond((float) 2.5));
+
+        lineRenderer.setLegendItemLabelGenerator(
+                new StandardXYSeriesLabelGenerator() {
+                    private static final long serialVersionUID = 7593430826693873496L;
+                    public String generateLabel(XYDataset dataset, int series) {
+                        XYSeries xys = ((XYSeriesCollection)dataset).getSeries(series);
+                        return xys.getDescription();
+                    }
+                }
+        );
+
+        NumberAxis xAxis = new NumberAxis(xAxisName);
+        xAxis.setAutoRangeIncludesZero(false);
+        NumberAxis yAxis = new NumberAxis(yAxisName);
+        yAxis.setAutoRangeIncludesZero(false);
+        
+        XYSeriesCollection lineDataset = new XYSeriesCollection();
+        
+        XYPlot plot = chart.getXYPlot();
+        plot.setRangePannable(true);
+        plot.setDomainPannable(true);
+        plot.setDomainGridlinePaint(Color.DARK_GRAY);
+        plot.setRangeGridlinePaint(Color.DARK_GRAY);
+        plot.setBackgroundPaint(new Color(224, 224, 224));
+
+        plot.setDataset(0, lineDataset);
+        plot.setRenderer(0, lineRenderer);
+        plot.setDomainAxis(0, xAxis);
+        plot.setRangeAxis(0, yAxis);
+        plot.mapDatasetToDomainAxis(0, 0);
+        plot.mapDatasetToRangeAxis(0, 0);
+        
+        LegendTitle legend = new LegendTitle(plot.getRenderer()); 
+        legend.setItemFont(new Font("Arial", 0, 10));
+        legend.setPosition(RectangleEdge.TOP);
+        chart.addLegend(legend);
+    }
+    
+    //////////////////////////////////////////////////////////////////////////////////////
+    // CREATE USAGE TAB
+    //////////////////////////////////////////////////////////////////////////////////////
+    
+    protected String usage() {
+        ResourceBundle bundle;
+        bundle = ResourceBundle.getBundle("com.vgi.mafscaling.veplus");
+        return bundle.getString("usage"); 
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////
+    // COMMOMN ACTIONS RELATED FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////////////////
+    
+    private boolean getColumnsFilters(String[] elements) {
+        boolean ret = true;
+        ArrayList<String> columns = new ArrayList<String>(Arrays.asList(elements));
+        String logClOlStatusColName = Config.getClOlStatusColumnName();
+        String logThrottleAngleColName = Config.getThrottleAngleColumnName();
+        String logFfbColName = Config.getFinalFuelingBaseColumnName();
+        String logSdColName = Config.getVEFlowColumnName();
+        String logWbAfrColName = Config.getWidebandAfrColumnName();
+        String logStockAfrColName = Config.getAfrColumnName();
+        String logAfLearningColName = Config.getAfLearningColumnName();
+        String logAfCorrectionColName = Config.getAfCorrectionColumnName();
+        String logRpmColName = Config.getRpmColumnName();
+        String logMafColName = Config.getMassAirflowColumnName();
+        String logIatColName = Config.getIatColumnName();
+        String logMpColName = Config.getMpColumnName();
+        logClOlStatusColIdx = columns.indexOf(logClOlStatusColName);
+        logThrottleAngleColIdx = columns.indexOf(logThrottleAngleColName);
+        logFfbColIdx = columns.indexOf(logFfbColName);
+        logSdColIdx = columns.indexOf(logSdColName);
+        logWbAfrColIdx = columns.indexOf(logWbAfrColName);
+        logStockAfrColIdx = columns.indexOf(logStockAfrColName);
+        logAfLearningColIdx = columns.indexOf(logAfLearningColName);
+        logAfCorrectionColIdx = columns.indexOf(logAfCorrectionColName);
+        logRpmColIdx = columns.indexOf(logRpmColName);
+        logMafColIdx = columns.indexOf(logMafColName);
+        logIatColIdx = columns.indexOf(logIatColName);
+        logMpColIdx = columns.indexOf(logMpColName);
+        fullTimeOl = Config.veFullTimeOl();
+        if (logClOlStatusColIdx == -1 && !fullTimeOl) { Config.setClOlStatusColumnName(Config.NO_NAME); ret = false; }
+        if (logThrottleAngleColIdx == -1)        { Config.setThrottleAngleColumnName(Config.NO_NAME);    ret = false; }
+        if (logFfbColIdx == -1)                  { Config.setFinalFuelingBaseColumnName(Config.NO_NAME); ret = false; }
+        if (logSdColIdx == -1)                   { Config.setVEFlowColumnName(Config.NO_NAME);           ret = false; }
+        if (logWbAfrColIdx == -1)        { Config.setWidebandAfrColumnName(Config.NO_NAME);      ret = false; }
+        if (logStockAfrColIdx == -1)    { Config.setAfrColumnName(Config.NO_NAME);              ret = false; }
+        if (logAfLearningColIdx == -1 && !fullTimeOl)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
+        if (logAfCorrectionColIdx == -1 && !fullTimeOl){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
+        if (logRpmColIdx == -1)                  { Config.setRpmColumnName(Config.NO_NAME);              ret = false; }
+        boolean mafMode = (dataType.getSelectedIndex() == 0);
+        if (logMafColIdx == -1) { Config.setMassAirflowColumnName(Config.NO_NAME); if (mafMode) ret = false; }
+        if (logMpColIdx == -1)                   { Config.setMpColumnName(Config.NO_NAME);               ret = false; }
+        if (logIatColIdx == -1)                  { Config.setIatColumnName(Config.NO_NAME);              ret = false; }
+        rpmMin = Config.getVERPMMinimumValue();
+        mpMin = Config.getVEMPMinimumValue();
+        iatMax = Config.getVEIatMaximumValue();
+        ffbMax = Config.getFFBMaximumValue();
+        ffbMin = Config.getFFBMinimumValue();
+        thrtlMaxChange = Config.getVEThrottleChangeMaxValue();
+        minCellHitCount = Config.getVEMinCellHitCount();
+        thrtlMin = Config.getVEThrottleMinimumValue();
+        afrMaxOl = Config.getVEOlAfrMaximumValue();
+        afrMaxCl = Config.getVEClAfrMaximumValue();
+        afrMinOl = Config.getVEOlAfrMinimumValue();
+        afrMinCl = Config.getVEClAfrMinimumValue();
+        afrRowOffset = Config.getWBO2RowOffset();
+        corrApplied = Config.getVECorrectionAppliedValue();
+        afrSwitchMp = Config.getVEWbAfrMpSwitch();
+        afrSwitchRpm = Config.getVEWbAfrRpmSwitch();
+        afrSmooth = Config.getVEWbAfrSmooth();
+        return ret;
+    }
+    
+    protected void loadLogFile() {
+        boolean displayDialog = true;
+        fileChooser.setMultiSelectionEnabled(true);
+        if (JFileChooser.APPROVE_OPTION != fileChooser.showOpenDialog(this))
+            return;
+        File[] files = fileChooser.getSelectedFiles();
+        for (File file : files) {
+            BufferedReader br = null;
+            ArrayDeque<String[]> buffer = new ArrayDeque<String[]>();
+            try {
+                br = new BufferedReader(new InputStreamReader(new FileInputStream(file.getAbsoluteFile()), Config.getEncoding()));
+                String line = null;
+                String [] elements = null;
+                while ((line = br.readLine()) != null && (elements = line.trim().split(Utils.fileFieldSplitter, -1)) != null && elements.length < 2)
+                    continue;
+                getColumnsFilters(elements);
+                boolean resetColumns = false;
+                boolean mafMode = (dataType.getSelectedIndex() == 0);
+                if (logThrottleAngleColIdx >= 0 || logFfbColIdx >= 0 || logSdColIdx >= 0 ||
+                    logWbAfrColIdx >= 0 || logStockAfrColIdx >= 0 || logAfLearningColIdx >= 0 || logAfCorrectionColIdx >= 0 ||
+                    logRpmColIdx >= 0 || (mafMode && logMafColIdx >= 0) || logIatColIdx >= 0 || logMpColIdx >= 0) {
+                    if (displayDialog) {
+                        int rc = JOptionPane.showOptionDialog(null, "Would you like to reset column names or filter values?", "Columns/Filters Reset", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, optionButtons, optionButtons[0]);
+                        if (rc == 0)
+                            resetColumns = true;
+                        else if (rc == 2)
+                            displayDialog = false;
+                    }
+                }
+
+                if (resetColumns || logThrottleAngleColIdx < 0 || logFfbColIdx < 0 || logSdColIdx < 0 || logWbAfrColIdx < 0 ||
+                    logStockAfrColIdx < 0 || logAfLearningColIdx < 0 || logAfCorrectionColIdx < 0 ||
+                    logRpmColIdx < 0 || (mafMode && logMafColIdx < 0) || logIatColIdx < 0 || logMpColIdx < 0) {
+                    ColumnsFiltersSelection selectionWindow = new VEColumnsFiltersSelection(mafMode);
+                    if (!selectionWindow.getUserSettings(elements) || !getColumnsFilters(elements))
+                        return;
+                }
+                
+                
+                String[] flds;
+                String[] afrflds;
+                boolean removed = false;
+                int i = 2;
+                int clol = -1;
+                int row = getLogTableEmptyRow();
+                double thrtlMaxChange2 = thrtlMaxChange + thrtlMaxChange / 2.0;
+                double throttle = 0;
+                double pThrottle = 0;
+                double ppThrottle = 0;
+                double rpm;
+                double ffb;
+                double iat;
+                clearRunTables();
+                setCursor(new Cursor(Cursor.WAIT_CURSOR));
+                for (int k = 0; k <= afrRowOffset && line != null; ++k) {
+                    line = br.readLine();
+                    if (line != null)
+                        buffer.addFirst(line.trim().split(Utils.fileFieldSplitter, -1));
+                }
+                try {
+                    while (line != null && buffer.size() > afrRowOffset) {
+                        afrflds = buffer.getFirst();
+                        flds = buffer.removeLast();
+                        line = br.readLine();
+                        if (line != null)
+                            buffer.addFirst(line.trim().split(Utils.fileFieldSplitter, -1));
+                        ppThrottle = pThrottle;
+                        pThrottle = throttle;
+                        throttle = Double.valueOf(flds[logThrottleAngleColIdx]);
+                        try {
+                            if (row > 0 && Math.abs(pThrottle - throttle) > thrtlMaxChange) {
+                                if (!removed)
+                                    Utils.removeRow(row--, logDataTable);
+                                removed = true;
+                            }
+                            else if (row <= 0 || Math.abs(ppThrottle - throttle) <= thrtlMaxChange2) {
+                                // Filters
+                                rpm = Double.valueOf(flds[logRpmColIdx]);
+                                ffb = Double.valueOf(flds[logFfbColIdx]);
+                                iat = Double.valueOf(flds[logIatColIdx]);
+                                boolean isClosed = false;
+                                if (!fullTimeOl) {
+                                    String clStr = flds[logClOlStatusColIdx];
+                                    if (clStr.equalsIgnoreCase("on"))
+                                        clol = 0;
+                                    else if (clStr.equalsIgnoreCase("off"))
+                                        clol = 1;
+                                    else
+                                        clol = (int)Utils.parseValue(clStr);
+                                    isClosed = (clol == 0);
+                                }
+                                double afrStock = Double.valueOf(afrflds[logStockAfrColIdx]);
+                                double afrWb = Double.valueOf(afrflds[logWbAfrColIdx]);
+                                double afrEff;
+                                if (!fullTimeOl) {
+                                    afrEff = isClosed ? afrStock : afrWb;
+                                } else {
+                                    double mp = Double.valueOf(flds[logMpColIdx]);
+                                    double alpha;
+                                    if (afrSmooth <= 0)
+                                        alpha = (rpm >= afrSwitchRpm || mp >= afrSwitchMp) ? 1.0 : 0.0;
+                                    else {
+                                        double mpA = 0.5 + 0.5 * Math.tanh((mp - afrSwitchMp) / afrSmooth);
+                                        double rpmA = 0.5 + 0.5 * Math.tanh((rpm - afrSwitchRpm) / afrSmooth);
+                                        alpha = Math.max(mpA, rpmA);
+                                    }
+                                    if (alpha < 0)
+                                        alpha = 0;
+                                    else if (alpha > 1)
+                                        alpha = 1;
+                                    afrEff = afrStock * (1 - alpha) + afrWb * alpha;
+                                    isClosed = alpha < 0.5;
+                                }
+
+                                boolean flag = isClosed ? (afrMinCl <= afrEff && afrEff <= afrMaxCl)
+                                                     : (afrMinOl <= afrEff && afrEff <= afrMaxOl);
+                                if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
+                                    removed = false;
+                                    if (!fullTimeOl && isClosed)
+                                        trims.add(Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]));
+                                    else
+                                        trims.add(Double.NaN);
+                                    Utils.ensureRowCount(row + 1, logDataTable);
+                                    logDataTable.setValueAt(rpm, row, 0);
+                                    logDataTable.setValueAt(iat, row, 1);
+                                    logDataTable.setValueAt(Double.valueOf(flds[logMpColIdx]), row, 2);
+                                    logDataTable.setValueAt(ffb, row, 3);
+                                    logDataTable.setValueAt(afrStock, row, 4);
+                                    logDataTable.setValueAt(afrWb, row, 5);
+                                    logDataTable.setValueAt(afrEff, row, 6);
+                                    if (mafMode)
+                                        logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 7);
+                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, mafMode ? 8 : 7);
+                                    logDataTable.setValueAt(isClosed ? 1 : 0, row, mafMode ? 9 : 8);
+                                    row += 1;
+                                }
+                                else
+                                    removed = true;
+                            }
+                            else
+                                removed = true;
+                        }
+                        catch (NumberFormatException e) {
+                            logger.error(e);
+                            JOptionPane.showMessageDialog(null, "Error parsing number at " + file.getName() + " line " + i + ": " + e, "Error processing file", JOptionPane.ERROR_MESSAGE);
+                            return;
+                        }
+                        i += 1;
+                    }
+                }
+                finally {
+                    setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+                }
+            }
+            catch (Exception e) {
+                logger.error(e);
+                JOptionPane.showMessageDialog(null, e, "Error opening file", JOptionPane.ERROR_MESSAGE);
+            }
+            finally {
+                if (br != null) {
+                    try {
+                        br.close();
+                    }
+                    catch (IOException e) {
+                        logger.error(e);
+                    }
+                }
+            }
+        }
+    }
+
+    protected boolean processLog() {
+        try {
+            double mapG = 1;
+            double mapO = 0;
+            String mpStr = mpType.getSelectedItem().toString();
+            String sdStr = sdType.getSelectedItem().toString();
+            if (mpStr.contains("Torr"))
+                mapG = 1.0 / 51.715;
+            if (mpStr.contains("Abs") && sdStr.contains("RR"))
+                mapO = -14.7;
+            else if (mpStr.contains("Rel") && sdStr.contains("Cobb"))
+                mapO = 14.7;
+
+            String rpmStr, iatStr, afreStr, mafStr, ffbStr, clStr;
+            LogData logData;
+            xData = new HashMap<Double, HashMap<Double, ArrayList<LogData>>>();
+            HashMap<Double, ArrayList<LogData>> yData;
+            ArrayList<LogData> data;
+            boolean mafMode = (dataType.getSelectedIndex() == 0);
+            for (int i = 0; i < logDataTable.getRowCount(); ++i) {
+                rpmStr = logDataTable.getValueAt(i, 0).toString();
+                iatStr = logDataTable.getValueAt(i, 1).toString();
+                mpStr  = logDataTable.getValueAt(i, 2).toString();
+                ffbStr = logDataTable.getValueAt(i, 3).toString();
+                afreStr = logDataTable.getValueAt(i, 6).toString();
+                mafStr = mafMode ? logDataTable.getValueAt(i, 7).toString() : "";
+                sdStr  = logDataTable.getValueAt(i, mafMode ? 8 : 7).toString();
+                clStr  = logDataTable.getValueAt(i, mafMode ? 9 : 8).toString();
+                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afreStr.isEmpty() || (mafMode && mafStr.isEmpty()) || ffbStr.isEmpty() || sdStr.isEmpty())
+                    continue;
+                logData = new LogData();
+                logData.mp = (Double.valueOf(mpStr) * mapG) + mapO;
+                
+                if (logData.mp < mpMin)
+                    continue;
+                
+                logData.rpm = Double.valueOf(rpmStr);
+                logData.mp = xAxisArray.get(Utils.closestValueIndex(logData.mp, xAxisArray));
+                logData.rpm = yAxisArray.get(Utils.closestValueIndex(logData.rpm, yAxisArray));
+                logData.iat = Double.valueOf(iatStr);
+                if (mafMode) {
+                    logData.maf = Double.valueOf(mafStr);
+                    logData.sd = Double.valueOf(sdStr);
+                } else {
+                    logData.maf = Double.NaN;
+                    logData.sd = Double.valueOf(sdStr);
+                }
+                logData.afr = Double.valueOf(afreStr);
+                try {
+                    logData.cl = Integer.parseInt(clStr);
+                } catch (Exception ex) {
+                    logData.cl = 0;
+                }
+                logData.ffb = Double.valueOf(ffbStr);
+                if (mafMode)
+                    logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
+                else
+                    logData.sderr = 0.0;
+                if (Double.isNaN(trims.get(i)))
+                    logData.afrerr = ((logData.afr - logData.ffb) / logData.ffb) * 100.0;
+                else
+                    logData.afrerr = trims.get(i);
+                
+                yData = xData.get(logData.mp);
+                if (yData == null) {
+                    yData = new HashMap<Double, ArrayList<LogData>>();
+                    xData.put(logData.mp, yData);
+                }
+                data = yData.get(logData.rpm);
+                if (data == null) {
+                    data = new ArrayList<LogData>();
+                    yData.put(logData.rpm, data);
+                }
+                data.add(logData);
+            }            
+            return true;
+        }
+        catch (Exception e) {
+            logger.error(e);
+            JOptionPane.showMessageDialog(null, e, "Error processing data", JOptionPane.ERROR_MESSAGE);
+        }
+        return false;
+    }
+    
+    protected boolean displayData() {
+        try {
+            int cnt;
+            double x, y, val;
+            boolean isMaf = (dataType.getSelectedIndex() == 0? true : false);
+            ArrayList<LogData> data;
+            HashMap<Double, ArrayList<LogData>> yData;
+            Color[][] colorMatrix = new Color[corrTable.getRowCount()][corrTable.getColumnCount()];
+            for (int i = 1; i < xAxisArray.size() + 1; ++i) {
+                newTable.setValueAt(origTable.getValueAt(0, i), 0, i);
+                corrTable.setValueAt(origTable.getValueAt(0, i), 0, i);
+                corrCountTable.setValueAt(origTable.getValueAt(0, i), 0, i);
+                for (int j = 1; j < yAxisArray.size() + 1; ++j) {
+                    if (i == 1) {
+                        newTable.setValueAt(origTable.getValueAt(j, 0), j, 0);
+                        corrTable.setValueAt(origTable.getValueAt(j, 0), j, 0);
+                        corrCountTable.setValueAt(origTable.getValueAt(j, 0), j, 0);
+                    }
+                    x = xAxisArray.get(i - 1);
+                    y = yAxisArray.get(j - 1);
+                    yData = xData.get(x);
+                    if (yData == null)
+                        newTable.setValueAt(origTable.getValueAt(j, i), j, i);
+                    else {
+                        data = yData.get(y);
+                        if (data == null)
+                            newTable.setValueAt(origTable.getValueAt(j, i), j, i);
+                        else {
+                            cnt = data.size();
+                            val = 0;
+                            for (LogData d : data)
+                                val += (isMaf ? d.sderr : d.afrerr);
+                            val /= cnt;
+                            corrTable.setValueAt(val, j, i);
+                            corrCountTable.setValueAt(cnt, j, i);
+                            if (cnt > minCellHitCount) {
+                                val = 1 + (val / 100.0 * corrApplied) / 100.0;
+                                if (isMaf)
+                                    newTable.setValueAt(Double.valueOf(origTable.getValueAt(j, i).toString()) / val, j, i);
+                                else
+                                    newTable.setValueAt(Double.valueOf(origTable.getValueAt(j, i).toString()) * val, j, i);
+                                colorMatrix[j][i] = Color.PINK;
+                            }
+                            else
+                                newTable.setValueAt(origTable.getValueAt(j, i), j, i);
+                        }
+                    }
+                }
+            }
+            Utils.colorTable(newTable);
+            
+            for (int i = 0; i < colorMatrix.length; ++i)
+                colorMatrix[i][0] = Color.LIGHT_GRAY;
+            for (int i = 0; i < colorMatrix[0].length; ++i)
+                colorMatrix[0][i] = Color.LIGHT_GRAY;
+            ((BgColorFormatRenderer)corrTable.getDefaultRenderer(Object.class)).setColors(colorMatrix);
+            ((BgColorFormatRenderer)corrCountTable.getDefaultRenderer(Object.class)).setColors(colorMatrix);
+            
+            plotCorrectionData();
+            
+            return true;
+        }
+        catch (Exception e) {
+            logger.error(e);
+            JOptionPane.showMessageDialog(null, e, "Error processing data", JOptionPane.ERROR_MESSAGE);
+        }
+        return false;        
+    }
+    
+    private void clearChartData() {
+        trims.clear();
+        runData.clear();
+        trendData.clear();
+    }
+
+    private void updateMafColumnVisibility() {
+        if (mafColumn == null || logDataTable == null)
+            return;
+        boolean isMafMode = (dataType.getSelectedIndex() == 0);
+        TableColumnModel model = logDataTable.getColumnModel();
+        boolean hasColumn;
+        try {
+            model.getColumnIndex(mafColumn.getIdentifier());
+            hasColumn = true;
+        } catch (IllegalArgumentException ex) {
+            hasColumn = false;
+        }
+        if (isMafMode && !hasColumn) {
+            model.addColumn(mafColumn);
+            model.moveColumn(model.getColumnCount() - 1, 7);
+        } else if (!isMafMode && hasColumn) {
+            model.removeColumn(mafColumn);
+        }
+    }
+    
+    protected void clearLogDataTables() {
+        super.clearLogDataTables();
+        clearChartData();
+    }
+
+    private boolean plotCorrectionData() {
+        plot3d.removeAllPlots();
+        XYSeries series;
+        XYPlot plot = chartPanel.getChart().getXYPlot();
+        XYSeriesCollection lineDataset = (XYSeriesCollection) plot.getDataset(0);
+        DecimalFormat df = new DecimalFormat(".00");
+        String val;
+        int i = 0;
+        int j = 0;
+        if (!Utils.isTableEmpty(corrTable)) {
+            try {
+                for (i = 1; i < corrTable.getColumnCount(); ++i) {
+                    val = corrTable.getValueAt(0, i).toString();
+                    series = new XYSeries(df.format(Double.valueOf(val)));
+                    for (j = 1; j < corrTable.getRowCount(); ++j) { 
+                        if (corrTable.getValueAt(j, i) != null) {
+                            val = corrTable.getValueAt(j, i).toString();
+                            if (!val.isEmpty())
+                                series.add(Double.valueOf(corrTable.getValueAt(j, 0).toString()), Double.valueOf(val));
+                        }
+                    }
+                    if (series.getItemCount() > 0) {
+                        corrData.add(series);
+                        series.setDescription(series.getKey().toString());
+                        lineDataset.addSeries(series);
+                    }
+                }
+                plot.getDomainAxis(0).setAutoRange(true);
+                plot.getRangeAxis(0).setAutoRange(true);
+                plot.getDomainAxis(0).setLabel(xAxisName);
+                plot.getRangeAxis(0).setLabel(yAxisName);
+                plot.getRenderer(0).setSeriesVisible(0, false);
+
+                double[] x = new double[xAxisArray.size()];
+                for (i = 0; i < xAxisArray.size(); ++i)
+                    x[i] = xAxisArray.get(i);
+                double[] y = new double[yAxisArray.size()];
+                for (i = 0; i < yAxisArray.size(); ++i)
+                    y[i] = yAxisArray.get(i);
+                double[][] z = Utils.doubleZArray(corrTable, x, y);
+                Color[][] tableColors = Utils.generateTableColorMatrix(corrTable, 1, 1, y.length + 1, x.length + 1);
+                Color[][] colors = new Color[y.length][x.length];
+                for (j = 1; j < tableColors.length; ++j)
+                    for (i = 1; i < tableColors[j].length; ++i)
+                        colors[j - 1][i - 1] = tableColors[j][i];
+                plot3d.addGridPlot("Average Error % Plot", colors, x, y, z);
+            }
+            catch (NumberFormatException e) {
+                logger.error(e);
+                JOptionPane.showMessageDialog(null, "Error parsing number from " + corrTableName + " table, cell(" + i + " : " + j + "): " + e, "Error", JOptionPane.ERROR_MESSAGE);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        checkActionPerformed(e);
+    }
+}

--- a/src/com/vgi/mafscaling/vecalc.properties
+++ b/src/com/vgi/mafscaling/vecalc.properties
@@ -32,7 +32,7 @@ This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which
 <h3>Usage:</h3>\
 <i></i>You really need to nail MAF scaling first!<br/><br/>\
 <ol style="list-style-type: decimal">\
-<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Mass Airflow&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status" (for CL/OL mode). \
+<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status" (for CL/OL mode). Log &quot;Mass Airflow&quot; only when using MAF Builder mode. \
 <li>Open your tune in RomRaider/Cobb AP and copy your current VE table into the first cell of &quot;Current VE table&quot; table on the tool.</li>\
 <li>Click on &quot;Load Log&quot; button, select your log file(s), select asked columns from log file AND set desired filters values. Once the log file is processed you should see data populated in the table</li>\
 <li>Select SD implementation you have from the drop down menu.</li>\

--- a/src/com/vgi/mafscaling/vecalc.properties
+++ b/src/com/vgi/mafscaling/vecalc.properties
@@ -4,7 +4,7 @@ usage=\
 This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which is used to build a VE base map using your current MAF.<br/>A special 'thank you' to 04ssti for testing this.<br/>\
 <p>There are essentially two main functions selectable via a drop down list:\
 <ul><li>MAF Builder - used to build Speed Density map based on your existing well working MAF scale by having your tune in MAF/SD mode</li>\
-<li>AFR Tuner - used to fine-tune existing SD table based on AFR. 'Closed Loop' or 'Open Loop' tuning can be selected when loading a log file</li><ul>\
+<li>AFR Tuner - used to fine-tune existing SD table based on AFR. The tool automatically switches between Closed Loop and Open Loop using the logged status</li><ul>\
 <h3>Logic:</h3>\
 <p>The tool is for adjusting Speed Density VE table based on an adjustment which is calculated as a average of corrections for a specific table cell.<br/>\
 <p>The correction will only be applied to cells where count of corrections is more than the cell hit count specified in settings.<br/>\
@@ -32,7 +32,7 @@ This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which
 <h3>Usage:</h3>\
 <i></i>You really need to nail MAF scaling first!<br/><br/>\
 <ol style="list-style-type: decimal">\
-<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and/or &quot;Stock AFR&quot; (for CL/OL), &quot;Mass Airflow&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status". \
+<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Mass Airflow&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status". \
 <li>Open your tune in RomRaider/Cobb AP and copy your current VE table into the first cell of &quot;Current VE table&quot; table on the tool.</li>\
 <li>Click on &quot;Load Log&quot; button, select your log file(s), select asked columns from log file AND set desired filters values. Once the log file is processed you should see data populated in the table</li>\
 <li>Select SD implementation you have from the drop down menu.</li>\

--- a/src/com/vgi/mafscaling/vecalc.properties
+++ b/src/com/vgi/mafscaling/vecalc.properties
@@ -4,7 +4,7 @@ usage=\
 This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which is used to build a VE base map using your current MAF.<br/>A special 'thank you' to 04ssti for testing this.<br/>\
 <p>There are essentially two main functions selectable via a drop down list:\
 <ul><li>MAF Builder - used to build Speed Density map based on your existing well working MAF scale by having your tune in MAF/SD mode</li>\
-<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs. In Full Time OL mode, AFR source is blended between Stock and Wideband based on MP/RPM filters.</li><ul>\
+<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs. In Full Time OL mode, AFR source is blended between Stock and Wideband based on MP/RPM filters (defaults: MP=1.0, RPM=3000, range=0.3).</li><ul>\
 <h3>Logic:</h3>\
 <p>The tool is for adjusting Speed Density VE table based on an adjustment which is calculated as a average of corrections for a specific table cell.<br/>\
 <p>The correction will only be applied to cells where count of corrections is more than the cell hit count specified in settings.<br/>\

--- a/src/com/vgi/mafscaling/vecalc.properties
+++ b/src/com/vgi/mafscaling/vecalc.properties
@@ -4,7 +4,7 @@ usage=\
 This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which is used to build a VE base map using your current MAF.<br/>A special 'thank you' to 04ssti for testing this.<br/>\
 <p>There are essentially two main functions selectable via a drop down list:\
 <ul><li>MAF Builder - used to build Speed Density map based on your existing well working MAF scale by having your tune in MAF/SD mode</li>\
-<li>AFR Tuner - used to fine-tune existing SD table based on AFR. The tool automatically switches between Closed Loop and Open Loop using the logged status</li><ul>\
+<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs</li><ul>\
 <h3>Logic:</h3>\
 <p>The tool is for adjusting Speed Density VE table based on an adjustment which is calculated as a average of corrections for a specific table cell.<br/>\
 <p>The correction will only be applied to cells where count of corrections is more than the cell hit count specified in settings.<br/>\
@@ -32,7 +32,7 @@ This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which
 <h3>Usage:</h3>\
 <i></i>You really need to nail MAF scaling first!<br/><br/>\
 <ol style="list-style-type: decimal">\
-<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Mass Airflow&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status". \
+<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Mass Airflow&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status" (for CL/OL mode). \
 <li>Open your tune in RomRaider/Cobb AP and copy your current VE table into the first cell of &quot;Current VE table&quot; table on the tool.</li>\
 <li>Click on &quot;Load Log&quot; button, select your log file(s), select asked columns from log file AND set desired filters values. Once the log file is processed you should see data populated in the table</li>\
 <li>Select SD implementation you have from the drop down menu.</li>\

--- a/src/com/vgi/mafscaling/vecalc.properties
+++ b/src/com/vgi/mafscaling/vecalc.properties
@@ -4,7 +4,7 @@ usage=\
 This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which is used to build a VE base map using your current MAF.<br/>A special 'thank you' to 04ssti for testing this.<br/>\
 <p>There are essentially two main functions selectable via a drop down list:\
 <ul><li>MAF Builder - used to build Speed Density map based on your existing well working MAF scale by having your tune in MAF/SD mode</li>\
-<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs</li><ul>\
+<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs. In Full Time OL mode, AFR source is blended between Stock and Wideband based on MP/RPM filters.</li><ul>\
 <h3>Logic:</h3>\
 <p>The tool is for adjusting Speed Density VE table based on an adjustment which is calculated as a average of corrections for a specific table cell.<br/>\
 <p>The correction will only be applied to cells where count of corrections is more than the cell hit count specified in settings.<br/>\

--- a/src/com/vgi/mafscaling/veplus.properties
+++ b/src/com/vgi/mafscaling/veplus.properties
@@ -1,0 +1,46 @@
+usage=\
+<html>\
+<h3>Credits:</h3>\
+This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which is used to build a VE base map using your current MAF.<br/>A special 'thank you' to 04ssti for testing this.<br/>\
+<p>There are essentially two main functions selectable via a drop down list:\
+<ul><li>MAF Builder - used to build Speed Density map based on your existing well working MAF scale by having your tune in MAF/SD mode</li>\
+<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs. In Full Time OL mode, AFR source is blended between Stock and Wideband based on MP/RPM filters (defaults: MP=1.0, RPM=3000, range=0.3).</li><ul>\
+<h3>Logic:</h3>\
+<p>The tool is for adjusting Speed Density VE table based on an adjustment which is calculated as a average of corrections for a specific table cell.<br/>\
+<p>The correction will only be applied to cells where count of corrections is more than the cell hit count specified in settings.<br/>\
+<p><i>The logic is as follow:</i><br/>\
+<p>Get per cell log data samples by finding nearest cell based on RPM and Manifold Pressure. If sample set is less than the cell hit count - discard it.\
+<p>For each sample set with count more than the specified cell hit count calculate average error % value . \
+<p>Error % for MAF Builder: \
+<div style="margin:20px; margin-top:5px">\
+    <div class="smallfont" style="margin-bottom:2px">Code:</div>\
+    <pre class="alt2" dir="ltr" style="margin: 0px; padding: 4px; border: 1px inset; text-align: left; overflow: auto">error % = (SD - MAF) / MAF) * 100</pre>\
+</div> \
+<p>Error % for AFR Tuner: \
+<ul><li>For Open Loop:</li>\
+<div style="margin:20px; margin-top:5px">\
+    <div class="smallfont" style="margin-bottom:2px">Code:</div>\
+    <pre class="alt2" dir="ltr" style="margin: 0px; padding: 4px; border: 1px inset; text-align: left; overflow: auto">error % = (AFR - FFB) / FFB) * 100</pre>\
+</div> \
+<li>For Closed Loop:</li>\
+<div style="margin:20px; margin-top:5px">\
+    <div class="smallfont" style="margin-bottom:2px">Code:</div>\
+    <pre class="alt2" dir="ltr" style="margin: 0px; padding: 4px; border: 1px inset; text-align: left; overflow: auto">error % = LTFT + STFT</pre>\
+</div></ul>\
+<p>For MAF the new VE table value for the cell is set as original cell value - adjustment.\
+<p>For AFR the new VE table value for the cell is set as original cell value + adjustment.\
+<h3>Usage:</h3>\
+<i></i>You really need to nail MAF scaling first!<br/><br/>\
+<ol style="list-style-type: decimal">\
+<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status" (for CL/OL mode). Log &quot;Mass Airflow&quot; only when using MAF Builder mode. \
+<li>Open your tune in RomRaider/Cobb AP and copy your current VE table into the first cell of &quot;Current VE table&quot; table on the tool.</li>\
+<li>Click on &quot;Load Log&quot; button, select your log file(s), select asked columns from log file AND set desired filters values. Once the log file is processed you should see data populated in the table</li>\
+<li>Select SD implementation you have from the drop down menu.</li>\
+<li>Select logged Manifold Pressure and units.</li>\
+<li>Select if you want to build SD correction based on MAF or based on AFR.</li>\
+<li>Click on &quot;GO&quot; button at the top bar right corner to generate new VE table data.</li>\
+<li>Copy the data to your SD table.</li>\
+<li>Once you have copied your new VE table values from the result table to your ROM, save a new ROM with the changes made.</li>\
+</ol>\
+More info can be found <a href="http://www.romraider.com/forum/viewtopic.php?f=32&t=8080">here</a><br/><br/><br/>\
+</html>\


### PR DESCRIPTION
## Summary
- simplify configuration by removing VE open loop flag
- show both AFR sensors when importing VE logs
- use closed/open loop status from logs when loading data
- describe automatic loop switching in usage notes

## Testing
- `ant jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889726309dc833182559da2630bf98f