### PR TITLE
Add VE+ tab with compensation table support

### DIFF
--- a/src/com/vgi/mafscaling/MafScaling.java
+++ b/src/com/vgi/mafscaling/MafScaling.java
@@ -46,6 +46,7 @@ public class MafScaling {
     private static final String LCTabName = "<html>Load Comp</html>";
     private static final String MITabName = "<html>MAF IAT Comp</html>";
     private static final String VETabName = "<html>MAF VE Calc</html>";
+    private static final String VPTabName = "<html>VE+</html>";
     private static final String VCTabName = "<html>WOT Best VVT</html>";
     private static final String LSTabName = "<html>Log Stats</html>";
     private static final String LVTabName = "<html>Log View</html>";
@@ -156,6 +157,10 @@ public class MafScaling {
         JTabbedPane ve = new VECalc(JTabbedPane.LEFT);
         ve.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
         tabbedPane.add(ve, VETabName);
+
+        JTabbedPane vp = new VEPlus(JTabbedPane.LEFT);
+        vp.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+        tabbedPane.add(vp, VPTabName);
 
         JTabbedPane vc = new VVTCalc(JTabbedPane.LEFT);
         vc.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);

--- a/src/com/vgi/mafscaling/VEPlus.java
+++ b/src/com/vgi/mafscaling/VEPlus.java
@@ -1,0 +1,32 @@
+package com.vgi.mafscaling;
+
+import java.awt.GridBagLayout;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+
+public class VEPlus extends VECalc {
+    private static final long serialVersionUID = 6485063587743412779L;
+    private JTable ectIatTable = null;
+    private JTable iatCompTable = null;
+
+    public VEPlus(int tabPlacement) {
+        super(tabPlacement);
+        setTitleAt(0, "<html><div style='text-align: center;'>V<br>E</div></html>");
+        createCompTab();
+    }
+
+    private void createCompTab() {
+        JPanel compPanel = new JPanel();
+        insertTab("<html><div style='text-align: center;'>C<br>o<br>m<br>p<br>s</div></html>", null, compPanel, null, 1);
+
+        GridBagLayout gbl_compPanel = new GridBagLayout();
+        gbl_compPanel.columnWidths = new int[]{0, 0};
+        gbl_compPanel.rowHeights = new int[]{0, 0, 0, 0, 0};
+        gbl_compPanel.columnWeights = new double[]{0.0, 1.0};
+        gbl_compPanel.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 1.0};
+        compPanel.setLayout(gbl_compPanel);
+
+        ectIatTable = createDataTable(compPanel, "Intake Port Temperature ECT/IAT Estimation Factor", TableRowCount, 2, 0, 0, true, false, true);
+        iatCompTable = createDataTable(compPanel, "VE IAT compensation", TableRowCount, 2, 0, 2, true, false, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add VE+ tab derived from VECalc
- rename Data tab to VE and introduce Comps tab
- allow pasting Intake Port Temperature and VE IAT comp tables
- expose VE+ tab from application

## Testing
- `ant -q jar`


------
https://chatgpt.com/codex/tasks/task_e_68a58d2614a88331a6b3d07ab59c34ba