### PR TITLE
Allow AFR Tuner without MAF input

### DIFF
--- a/src/com/vgi/mafscaling/ClosedLoop.java
+++ b/src/com/vgi/mafscaling/ClosedLoop.java
@@ -1083,12 +1083,13 @@ public class ClosedLoop extends AMafScaling {
                             dVdt = 100.0;
                         else
                             dVdt = Math.abs(((mafv - pmafv) / (time - prevTime)) * 1000.0);
-                        if (flds[logClOlStatusColIdx] == "on")
+                        String clStr = flds[logClOlStatusColIdx];
+                        if (clStr.equalsIgnoreCase("on"))
                             clol = 0;
-                        else if (flds[logClOlStatusColIdx] == "off")
+                        else if (clStr.equalsIgnoreCase("off"))
                             clol = 1;
                         else
-                            clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                            clol = (int)Utils.parseValue(clStr);
                         if (clol == clValue) {
                             // Filters
                             afr = Double.valueOf(flds[logAfrColIdx]);

--- a/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/ColumnsFiltersSelection.java
@@ -106,6 +106,9 @@ abstract class ColumnsFiltersSelection implements ActionListener {
     public static final String minWOTEnrichmentLabelText = "Min WOT Enrichment";
     public static final String wbo2RowOffsetLabelText = "Wideband AFR Row Offset";
     public static final String olClTransitionSkipRowsLabelText = "OL/CL Transition - #Rows to Skip";
+    public static final String afrMpSwitchLabelText = "WB AFR MP Switch";
+    public static final String afrRpmSwitchLabelText = "WB AFR RPM Switch";
+    public static final String afrSmoothLabelText = "WB AFR Blend Range";
     protected JTable columnsTable = null;
     protected JTextField thrtlAngleName = null;
     protected JTextField afLearningName = null;
@@ -142,6 +145,9 @@ abstract class ColumnsFiltersSelection implements ActionListener {
     protected JFormattedTextField olClTransitionSkipRowsField = null;
     protected JFormattedTextField maxAfrFilter = null;
     protected JFormattedTextField minAfrFilter = null;
+    protected JFormattedTextField afrMpSwitchFilter = null;
+    protected JFormattedTextField afrRpmSwitchFilter = null;
+    protected JFormattedTextField afrSmoothFilter = null;
     protected JFormattedTextField atmPressureFilter = null;
     protected JFormattedTextField maxIatFilter = null;
     protected JFormattedTextField maxDvdtFilter = null;
@@ -682,6 +688,27 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         wbo2RowOffsetField = addTextFilter(filtrow, intFmt);
         addDefaultButton(filtrow, "wbo2offset");
     }
+
+    protected void addAfrMpSwitchFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "MP where WB AFR starts to blend in");
+        addLabel(filtersPanel, ++filtrow, afrMpSwitchLabelText);
+        afrMpSwitchFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "wbswitchmp");
+    }
+
+    protected void addAfrRpmSwitchFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "RPM where WB AFR starts to blend in");
+        addLabel(filtersPanel, ++filtrow, afrRpmSwitchLabelText);
+        afrRpmSwitchFilter = addTextFilter(filtrow, intFmt);
+        addDefaultButton(filtrow, "wbswitchrpm");
+    }
+
+    protected void addAfrSmoothFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Blend transition range for switching Stock/WB AFR");
+        addLabel(filtersPanel, ++filtrow, afrSmoothLabelText);
+        afrSmoothFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "wbsmooth");
+    }
     
     protected void addOLCLTransitionSkipRowsFilter() {
         // OL/CL Transition skip rows
@@ -744,7 +771,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         return current;
     }
 
-    private void addCommentLabel(JPanel panel, int row, int colspan, String text) {
+    protected void addCommentLabel(JPanel panel, int row, int colspan, String text) {
         JLabel label = new JLabel(text);
         GridBagConstraints gbc_label = new GridBagConstraints();
         gbc_label.anchor = GridBagConstraints.WEST;
@@ -756,7 +783,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         panel.add(label, gbc_label);
     }
     
-    private void addLabel(JPanel panel, int row, String text) {
+    protected void addLabel(JPanel panel, int row, String text) {
         JLabel label = new JLabel(text);
         GridBagConstraints gbc_label = new GridBagConstraints();
         gbc_label.anchor = GridBagConstraints.EAST;
@@ -766,7 +793,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         panel.add(label, gbc_label);
     }
     
-    private void addNote(JPanel panel, int row, int colspan, String note) {
+    protected void addNote(JPanel panel, int row, int colspan, String note) {
         JEditorPane label = createWrapLabel(note);
         GridBagConstraints gbc_label = new GridBagConstraints();
         gbc_label.anchor = GridBagConstraints.WEST;
@@ -821,7 +848,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         columnsPanel.add(button, gbc_button);
     }
 
-    private JFormattedTextField addTextFilter(int row, NumberFormat format) {
+    protected JFormattedTextField addTextFilter(int row, NumberFormat format) {
         JFormattedTextField textField = new JFormattedTextField(format);
         textField.setColumns(6);
         textField.setBackground(Color.WHITE);
@@ -836,7 +863,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         return textField;
     }
     
-    private JSpinner addSpinnerFilter(int row, int value, int min, int max, int step) {
+    protected JSpinner addSpinnerFilter(int row, int value, int min, int max, int step) {
         JSpinner spinner = new JSpinner(new SpinnerNumberModel(value, min, max, step));
         GridBagConstraints gbc_spinner = new GridBagConstraints();
         gbc_spinner.anchor = GridBagConstraints.WEST;
@@ -872,7 +899,7 @@ abstract class ColumnsFiltersSelection implements ActionListener {
         return flag;
     }
     
-    private void addDefaultButton(int row, String action) {
+    protected void addDefaultButton(int row, String action) {
         JButton button = new JButton("default");
         GridBagConstraints gbc_button = new GridBagConstraints();
         gbc_button.anchor = GridBagConstraints.WEST;

--- a/src/com/vgi/mafscaling/Config.java
+++ b/src/com/vgi/mafscaling/Config.java
@@ -48,6 +48,9 @@ public class Config {
     public static final String DefaultAtmPressure = "14.7";
     public static final String DefaultVEThrottleChangeMax = "4";
     public static final String DefaultVEThrottleMinimum = "5";
+    public static final String DefaultVEClStatusValue = "0";
+    public static final String DefaultVEOlStatusValue = "1";
+    public static final String DefaultVEOlThrottleMinimum = "20";
     public static final String DefaultIsLoadCompInRatio = "false";
     public static final String DefaultIsMafIatInRatio = "false";    
     public static final String DefaultCLMinCellHitCount = "30";
@@ -79,6 +82,13 @@ public class Config {
     public static final String DefaultVEOlAfrMaximum = "16.0";
     public static final String DefaultVEClAfrMaximum = "15.0";
     public static final String DefaultVEAfrMinimum = "13.7";
+    public static final String DefaultVEOlAfrMinimum = "10.0";
+    public static final String DefaultVEClAfrMinimum = "13.7";
+    public static final String DefaultVEFullTimeOL = "false";
+    // Default thresholds for blending stock and wideband AFR when Full Time OL mode is enabled
+    public static final String DefaultVEWbAfrMpSwitch = "1.0";   // MP at which WB AFR blend starts
+    public static final String DefaultVEWbAfrRpmSwitch = "3000"; // RPM at which WB AFR blend starts
+    public static final String DefaultVEWbAfrSmooth = "0.3";    // Range over which blend transitions
     public static final String DefaultLoadMinimum = "0.2";
     public static final String DefaultDvDtMaximum = "0.7";
     public static final String DefaultMIAfrMaximum = "16.0";
@@ -88,7 +98,7 @@ public class Config {
     private static final String CFG_FILE = "config.xml";
     public static final String NO_NAME = "#$#";
     private static Properties props = new Properties();
-    public static boolean veOpenLoop = true;
+    public static boolean veFullTimeOl = false;
 
     public static String getProperty(String name) {
         return props.getProperty(name, "");
@@ -470,12 +480,20 @@ public class Config {
         props.setProperty("VECorrectionApplied", Integer.toString(v));
     }
 
-    public static int getVEClOlStatusValue() {
-        return Integer.parseInt(props.getProperty("VEClOlStatusValue", DefaultClOlStatusValue));
+    public static int getVEClStatusValue() {
+        return Integer.parseInt(props.getProperty("VEClStatusValue", DefaultVEClStatusValue));
     }
 
-    public static void setVEClOlStatusValue(int v) {
-        props.setProperty("VEClOlStatusValue", Integer.toString(v));
+    public static void setVEClStatusValue(int v) {
+        props.setProperty("VEClStatusValue", Integer.toString(v));
+    }
+
+    public static int getVEOlStatusValue() {
+        return Integer.parseInt(props.getProperty("VEOlStatusValue", DefaultVEOlStatusValue));
+    }
+
+    public static void setVEOlStatusValue(int v) {
+        props.setProperty("VEOlStatusValue", Integer.toString(v));
     }
     
     public static int getVEThrottleChangeMaxValue() {
@@ -492,6 +510,14 @@ public class Config {
 
     public static void setVEThrottleMinimumValue(int v) {
         props.setProperty("VEThrottleMinimum", Integer.toString(v));
+    }
+
+    public static int getVEOlThrottleMinimumValue() {
+        return Integer.parseInt(props.getProperty("VEOlThrottleMinimumValue", DefaultVEOlThrottleMinimum));
+    }
+
+    public static void setVEOlThrottleMinimumValue(int v) {
+        props.setProperty("VEOlThrottleMinimumValue", Integer.toString(v));
     }
 
     public static int getVEMinCellHitCount() {
@@ -540,6 +566,30 @@ public class Config {
 
     public static void setWBO2RowOffset(int v) {
         props.setProperty("WBO2RowOffset", Integer.toString(v));
+    }
+
+    public static double getVEWbAfrMpSwitch() {
+        return Double.parseDouble(props.getProperty("VEWbAfrMpSwitch", DefaultVEWbAfrMpSwitch));
+    }
+
+    public static void setVEWbAfrMpSwitch(double v) {
+        props.setProperty("VEWbAfrMpSwitch", Double.toString(v));
+    }
+
+    public static int getVEWbAfrRpmSwitch() {
+        return Integer.parseInt(props.getProperty("VEWbAfrRpmSwitch", DefaultVEWbAfrRpmSwitch));
+    }
+
+    public static void setVEWbAfrRpmSwitch(int v) {
+        props.setProperty("VEWbAfrRpmSwitch", Integer.toString(v));
+    }
+
+    public static double getVEWbAfrSmooth() {
+        return Double.parseDouble(props.getProperty("VEWbAfrSmooth", DefaultVEWbAfrSmooth));
+    }
+
+    public static void setVEWbAfrSmooth(double v) {
+        props.setProperty("VEWbAfrSmooth", Double.toString(v));
     }
 
     public static int getOLCLTransitionSkipRows() {
@@ -726,6 +776,22 @@ public class Config {
         props.setProperty("VEClAfrMaximum", Double.toString(v));
     }
 
+    public static double getVEOlAfrMinimumValue() {
+        return Double.parseDouble(props.getProperty("VEOlAfrMinimum", DefaultVEOlAfrMinimum));
+    }
+
+    public static void setVEOlAfrMinimumValue(double v) {
+        props.setProperty("VEOlAfrMinimum", Double.toString(v));
+    }
+
+    public static double getVEClAfrMinimumValue() {
+        return Double.parseDouble(props.getProperty("VEClAfrMinimum", DefaultVEClAfrMinimum));
+    }
+
+    public static void setVEClAfrMinimumValue(double v) {
+        props.setProperty("VEClAfrMinimum", Double.toString(v));
+    }
+
     public static double getVEAfrMinimumValue() {
         return Double.parseDouble(props.getProperty("VEAfrMinimum", DefaultVEAfrMinimum));
     }
@@ -821,14 +887,15 @@ public class Config {
     public static void setVVT2RPMColumn(String s) {
         props.setProperty("VVT2RPMColumn", s);
     }
-    
-    public static boolean veOpenLoop() {
-        return veOpenLoop;
+
+    public static boolean veFullTimeOl() {
+        return veFullTimeOl;
+    }
+
+    public static void veFullTimeOl(boolean f) {
+        veFullTimeOl = f;
     }
     
-    public static void veOpenLoop(boolean f) {
-        veOpenLoop = f;
-    }
     
     public static String getEncoding() {
         return props.getProperty("Encoding", DefaultEncoding);

--- a/src/com/vgi/mafscaling/MafIatComp.java
+++ b/src/com/vgi/mafscaling/MafIatComp.java
@@ -372,12 +372,13 @@ public class MafIatComp extends ACompCalc {
                             else if (row <= 2 || Math.abs(ppThrottle - throttle) <= thrtlMaxChange2) {
                                 // Filters
                                 trims = Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]);
-                                if (flds[logClOlStatusColIdx] == "on")
+                                String clStr = flds[logClOlStatusColIdx];
+                                if (clStr.equalsIgnoreCase("on"))
                                     clol = 0;
-                                else if (flds[logClOlStatusColIdx] == "off")
+                                else if (clStr.equalsIgnoreCase("off"))
                                     clol = 1;
                                 else
-                                    clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                    clol = (int)Utils.parseValue(clStr);
                                 if (clValue == clol) {
                                     afr = Double.valueOf(flds[logAfrColIdx]);
                                     corr = (100.0 + trims) / 100.0;

--- a/src/com/vgi/mafscaling/VECalc.java
+++ b/src/com/vgi/mafscaling/VECalc.java
@@ -27,6 +27,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Stroke;
 import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -39,6 +40,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.ResourceBundle;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -75,24 +78,36 @@ public class VECalc extends ACompCalc {
         public double sd = 0;
         public double sderr = 0;
         public double afrerr = 0;
+        public double afrerrCl = 0;
+        public double afrerrOl = 0;
+        public double afrStock = 0;
+        public double afrWb = 0;
+        public int cl = 0;
     }
 
     private static final String xAxisName = "RPM";
     private static final String yAxisName = "Estimated VE";
-    private int clValue = Config.getVEClOlStatusValue();
     private int afrRowOffset = Config.getWBO2RowOffset();
     private int thrtlMaxChange = Config.getVEThrottleChangeMaxValue();
     private int minCellHitCount = Config.getVEMinCellHitCount();
     private double thrtlMin = Config.getVEThrottleMinimumValue();
-    private double afrMax = Config.getVEOlAfrMaximumValue();
-    private double afrMin = Config.getVEAfrMinimumValue();
+    private double afrMaxOl = Config.getVEOlAfrMaximumValue();
+    private double afrMaxCl = Config.getVEClAfrMaximumValue();
+    private double afrMinOl = Config.getVEOlAfrMinimumValue();
+    private double afrMinCl = Config.getVEClAfrMinimumValue();
     private double rpmMin = Config.getVERPMMinimumValue();
     private double ffbMax = Config.getFFBMaximumValue();
     private double ffbMin = Config.getFFBMinimumValue();
     private double mpMin = Config.getVEMPMinimumValue();
     private double iatMax = Config.getVEIatMaximumValue();
-    private boolean isOl = Config.veOpenLoop();
     private int corrApplied = Config.getVECorrectionAppliedValue();
+    private boolean fullTimeOl = Config.veFullTimeOl();
+    private double afrSwitchMp = Config.getVEWbAfrMpSwitch();
+    private int afrSwitchRpm = Config.getVEWbAfrRpmSwitch();
+    private double afrSmooth = Config.getVEWbAfrSmooth();
+    private int olThrtlMin = Config.getVEOlThrottleMinimumValue();
+    private int clStatusValue = Config.getVEClStatusValue();
+    private int olStatusValue = Config.getVEOlStatusValue();
     private int logClOlStatusColIdx = -1;
     private int logThrottleAngleColIdx = -1;
     private int logRpmColIdx = -1;
@@ -102,15 +117,15 @@ public class VECalc extends ACompCalc {
     private int logStockAfrColIdx = -1;
     private int logAfLearningColIdx = -1;
     private int logAfCorrectionColIdx = -1;
-    private int logMafColIdx = -1;    
-    private int logFfbColIdx = -1;    
+    private int logMafColIdx = -1;
+    private int logFfbColIdx = -1;
     private int logSdColIdx = -1;
+    private TableColumn mafColumn = null;
     
-    private String[] logColumns = new String[] { "RPM", "IAT", "MP", "FFB", "AFR", "MAF", "VE" };
+    private String[] logColumns = new String[] { "RPM", "IAT", "MP", "FFB", "AFR", "WB", "AFRE", "ECL", "EOL", "E", "MAF", "VE", "CL" };
     private JComboBox<String> sdType = null;
     private JComboBox<String> mpType = null;
     private JComboBox<String> dataType = null;
-    private ArrayList<Double> trims = new ArrayList<Double>();
     private HashMap<Double, HashMap<Double, ArrayList<LogData>>> xData = null;
 
     public VECalc(int tabPlacement) {
@@ -123,6 +138,9 @@ public class VECalc extends ACompCalc {
         y3dAxisName = "RPM";
         z3dAxisName = "Avg Error %";
         initialize(logColumns);
+        mafColumn = logDataTable.getColumnModel().getColumn(10);
+        mafColumn.setIdentifier("MAF");
+        updateMafColumnVisibility();
     }
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -158,6 +176,7 @@ public class VECalc extends ACompCalc {
         mpType = addComboBox(cntlPanel, 7, new String [] { "Torr/mmHG Abs", "Torr/mmHG Rel Sea Lvl", "Psi Abs", "Psi Rel Sea Lvl" });
         addLabel(cntlPanel, 8, "Run");
         dataType = addComboBox(cntlPanel, 9, new String [] { "MAF Builder", "AFR Tuner" });
+        dataType.addItemListener(e -> { if (e.getStateChange() == ItemEvent.SELECTED) updateMafColumnVisibility(); });
         addCheckBox(cntlPanel, 10, "Hide Log Table", "hidelogtable");
         compareTableCheckBox = addCheckBox(cntlPanel, 11, "Compare Tables", "comparetables");
         addButton(cntlPanel, 12, "GO", "go", GridBagConstraints.EAST);
@@ -313,7 +332,6 @@ public class VECalc extends ACompCalc {
         String logMafColName = Config.getMassAirflowColumnName();
         String logIatColName = Config.getIatColumnName();
         String logMpColName = Config.getMpColumnName();
-        isOl = Config.veOpenLoop();
         logClOlStatusColIdx = columns.indexOf(logClOlStatusColName);
         logThrottleAngleColIdx = columns.indexOf(logThrottleAngleColName);
         logFfbColIdx = columns.indexOf(logFfbColName);
@@ -326,18 +344,20 @@ public class VECalc extends ACompCalc {
         logMafColIdx = columns.indexOf(logMafColName);
         logIatColIdx = columns.indexOf(logIatColName);
         logMpColIdx = columns.indexOf(logMpColName);
+        fullTimeOl = Config.veFullTimeOl();
+        if (logClOlStatusColIdx == -1 && !fullTimeOl) { Config.setClOlStatusColumnName(Config.NO_NAME); ret = false; }
         if (logThrottleAngleColIdx == -1)        { Config.setThrottleAngleColumnName(Config.NO_NAME);    ret = false; }
         if (logFfbColIdx == -1)                  { Config.setFinalFuelingBaseColumnName(Config.NO_NAME); ret = false; }
         if (logSdColIdx == -1)                   { Config.setVEFlowColumnName(Config.NO_NAME);           ret = false; }
-        if (logWbAfrColIdx == -1 && isOl)        { Config.setWidebandAfrColumnName(Config.NO_NAME);      ret = false; }
-        if (logStockAfrColIdx == -1 && !isOl)    { Config.setAfrColumnName(Config.NO_NAME);              ret = false; }
-        if (logAfLearningColIdx == -1 && !isOl)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
-        if (logAfCorrectionColIdx == -1 && !isOl){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
+        if (logWbAfrColIdx == -1)        { Config.setWidebandAfrColumnName(Config.NO_NAME);      ret = false; }
+        if (logStockAfrColIdx == -1)    { Config.setAfrColumnName(Config.NO_NAME);              ret = false; }
+        if (logAfLearningColIdx == -1 && !fullTimeOl)  { Config.setAfLearningColumnName(Config.NO_NAME);       ret = false; }
+        if (logAfCorrectionColIdx == -1 && !fullTimeOl){ Config.setAfCorrectionColumnName(Config.NO_NAME);     ret = false; }
         if (logRpmColIdx == -1)                  { Config.setRpmColumnName(Config.NO_NAME);              ret = false; }
-        if (logMafColIdx == -1)                  { Config.setMassAirflowColumnName(Config.NO_NAME);      ret = false; }
+        boolean mafMode = (dataType.getSelectedIndex() == 0);
+        if (logMafColIdx == -1) { Config.setMassAirflowColumnName(Config.NO_NAME); if (mafMode) ret = false; }
         if (logMpColIdx == -1)                   { Config.setMpColumnName(Config.NO_NAME);               ret = false; }
         if (logIatColIdx == -1)                  { Config.setIatColumnName(Config.NO_NAME);              ret = false; }
-        clValue = Config.getVEClOlStatusValue();
         rpmMin = Config.getVERPMMinimumValue();
         mpMin = Config.getVEMPMinimumValue();
         iatMax = Config.getVEIatMaximumValue();
@@ -346,10 +366,18 @@ public class VECalc extends ACompCalc {
         thrtlMaxChange = Config.getVEThrottleChangeMaxValue();
         minCellHitCount = Config.getVEMinCellHitCount();
         thrtlMin = Config.getVEThrottleMinimumValue();
-        afrMax = (isOl ? Config.getVEOlAfrMaximumValue() : Config.getVEClAfrMaximumValue());
-        afrMin = Config.getVEAfrMinimumValue();
+        afrMaxOl = Config.getVEOlAfrMaximumValue();
+        afrMaxCl = Config.getVEClAfrMaximumValue();
+        afrMinOl = Config.getVEOlAfrMinimumValue();
+        afrMinCl = Config.getVEClAfrMinimumValue();
         afrRowOffset = Config.getWBO2RowOffset();
         corrApplied = Config.getVECorrectionAppliedValue();
+        afrSwitchMp = Config.getVEWbAfrMpSwitch();
+        afrSwitchRpm = Config.getVEWbAfrRpmSwitch();
+        afrSmooth = Config.getVEWbAfrSmooth();
+        olThrtlMin = Config.getVEOlThrottleMinimumValue();
+        clStatusValue = Config.getVEClStatusValue();
+        olStatusValue = Config.getVEOlStatusValue();
         return ret;
     }
     
@@ -370,9 +398,10 @@ public class VECalc extends ACompCalc {
                     continue;
                 getColumnsFilters(elements);
                 boolean resetColumns = false;
-                if (logThrottleAngleColIdx >= 0 || logFfbColIdx >= 0 || logSdColIdx >= 0 || (logWbAfrColIdx >= 0 && isOl) ||
-                    (logStockAfrColIdx >= 0 && !isOl) || (logAfLearningColIdx >= 0 && !isOl) || (logAfCorrectionColIdx >= 0 && !isOl) ||
-                    logRpmColIdx >= 0 || logMafColIdx >= 0 || logIatColIdx >= 0 || logMpColIdx >= 0) {
+                boolean mafMode = (dataType.getSelectedIndex() == 0);
+                if (logThrottleAngleColIdx >= 0 || logFfbColIdx >= 0 || logSdColIdx >= 0 ||
+                    logWbAfrColIdx >= 0 || logStockAfrColIdx >= 0 || logAfLearningColIdx >= 0 || logAfCorrectionColIdx >= 0 ||
+                    logRpmColIdx >= 0 || (mafMode && logMafColIdx >= 0) || logIatColIdx >= 0 || logMpColIdx >= 0) {
                     if (displayDialog) {
                         int rc = JOptionPane.showOptionDialog(null, "Would you like to reset column names or filter values?", "Columns/Filters Reset", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, optionButtons, optionButtons[0]);
                         if (rc == 0)
@@ -382,16 +411,14 @@ public class VECalc extends ACompCalc {
                     }
                 }
 
-                if (resetColumns || logThrottleAngleColIdx < 0 || logFfbColIdx < 0 || logSdColIdx < 0 || (logWbAfrColIdx < 0 && isOl) ||
-                    (logStockAfrColIdx < 0 && !isOl) || (logAfLearningColIdx < 0 && !isOl) || (logAfCorrectionColIdx < 0 && !isOl) ||
-                    logRpmColIdx < 0 || logMafColIdx < 0 || logIatColIdx < 0 || logMpColIdx < 0) {
-                    ColumnsFiltersSelection selectionWindow = new VEColumnsFiltersSelection();
+                if (resetColumns || logThrottleAngleColIdx < 0 || logFfbColIdx < 0 || logSdColIdx < 0 || logWbAfrColIdx < 0 ||
+                    logStockAfrColIdx < 0 || logAfLearningColIdx < 0 || logAfCorrectionColIdx < 0 ||
+                    logRpmColIdx < 0 || (mafMode && logMafColIdx < 0) || logIatColIdx < 0 || logMpColIdx < 0) {
+                    ColumnsFiltersSelection selectionWindow = new VEColumnsFiltersSelection(mafMode);
                     if (!selectionWindow.getUserSettings(elements) || !getColumnsFilters(elements))
                         return;
                 }
                 
-                if (logClOlStatusColIdx == -1)
-                    clValue = -1;
                 
                 String[] flds;
                 String[] afrflds;
@@ -403,7 +430,6 @@ public class VECalc extends ACompCalc {
                 double throttle = 0;
                 double pThrottle = 0;
                 double ppThrottle = 0;
-                double afr = 0;
                 double rpm;
                 double ffb;
                 double iat;
@@ -432,32 +458,77 @@ public class VECalc extends ACompCalc {
                             }
                             else if (row <= 0 || Math.abs(ppThrottle - throttle) <= thrtlMaxChange2) {
                                 // Filters
-                                afr = (isOl ? Double.valueOf(afrflds[logWbAfrColIdx]) : Double.valueOf(afrflds[logStockAfrColIdx]));
                                 rpm = Double.valueOf(flds[logRpmColIdx]);
                                 ffb = Double.valueOf(flds[logFfbColIdx]);
                                 iat = Double.valueOf(flds[logIatColIdx]);
-                                if (clValue != -1)
-                                {
-                                    if (flds[logClOlStatusColIdx] == "on")
-                                        clol = 0;
-                                    else if (flds[logClOlStatusColIdx] == "off")
-                                        clol = 1;
+                                boolean isClosed = false;
+                                if (!fullTimeOl) {
+                                    String clStr = flds[logClOlStatusColIdx];
+                                    if (clStr.equalsIgnoreCase("on"))
+                                        clol = clStatusValue;
+                                    else if (clStr.equalsIgnoreCase("off"))
+                                        clol = olStatusValue;
                                     else
-                                        clol = (int)Utils.parseValue(flds[logClOlStatusColIdx]);
+                                        clol = (int)Utils.parseValue(clStr);
+                                    isClosed = (clol == clStatusValue);
                                 }
-                                boolean flag = isOl ? ((afr <= afrMax || throttle >= thrtlMin) && afr <= afrMax) : (afrMin <= afr);
-                                if (flag && clol == clValue && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
+                                double afrStock = Double.valueOf(afrflds[logStockAfrColIdx]);
+                                double afrWb = Double.valueOf(afrflds[logWbAfrColIdx]);
+                                double afrEff;
+                                if (!fullTimeOl) {
+                                    afrEff = isClosed ? afrStock : afrWb;
+                                } else {
+                                    double mp = Double.valueOf(flds[logMpColIdx]);
+                                    double alpha;
+                                    if (afrSmooth <= 0)
+                                        alpha = (rpm >= afrSwitchRpm || mp >= afrSwitchMp) ? 1.0 : 0.0;
+                                    else {
+                                        double mpA = 0.5 + 0.5 * Math.tanh((mp - afrSwitchMp) / afrSmooth);
+                                        double rpmA = 0.5 + 0.5 * Math.tanh((rpm - afrSwitchRpm) / afrSmooth);
+                                        alpha = Math.max(mpA, rpmA);
+                                    }
+                                    if (alpha < 0)
+                                        alpha = 0;
+                                    else if (alpha > 1)
+                                        alpha = 1;
+                                    afrEff = afrStock * (1 - alpha) + afrWb * alpha;
+                                    isClosed = alpha < 0.5;
+                                }
+
+                                double trim = Double.NaN;
+                                if (!fullTimeOl && isClosed)
+                                    trim = Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]);
+                                if (!fullTimeOl)
+                                    afrEff = isClosed ? ffb * (1 + trim / 100.0) : afrWb;
+
+                                double eol = ((afrWb - ffb) / ffb) * 100.0;
+                                double ecl = isClosed ? trim : 0.0;
+                                double e   = isClosed ? ecl : eol;
+
+                                boolean flag;
+                                if (fullTimeOl)
+                                    flag = isClosed ? (afrMinCl <= afrEff && afrEff <= afrMaxCl)
+                                                    : (afrMinOl <= afrEff && afrEff <= afrMaxOl);
+                                else
+                                    flag = isClosed ? true : (afrMinOl <= afrWb && afrWb <= afrMaxOl && throttle >= olThrtlMin);
+
+                                if (flag && rpmMin <= rpm && ffbMin <= ffb && ffb <= ffbMax && iat <= iatMax) {
                                     removed = false;
-                                    if (!isOl)
-                                        trims.add(Double.valueOf(flds[logAfLearningColIdx]) + Double.valueOf(flds[logAfCorrectionColIdx]));
                                     Utils.ensureRowCount(row + 1, logDataTable);
                                     logDataTable.setValueAt(rpm, row, 0);
                                     logDataTable.setValueAt(iat, row, 1);
                                     logDataTable.setValueAt(Double.valueOf(flds[logMpColIdx]), row, 2);
                                     logDataTable.setValueAt(ffb, row, 3);
-                                    logDataTable.setValueAt(afr, row, 4);
-                                    logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 5);
-                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, 6);
+                                    logDataTable.setValueAt(afrStock, row, 4);
+                                    logDataTable.setValueAt(afrWb, row, 5);
+                                    logDataTable.setValueAt(afrEff, row, 6);
+                                    logDataTable.setValueAt(ecl, row, 7);
+                                    logDataTable.setValueAt(eol, row, 8);
+                                    logDataTable.setValueAt(e, row, 9);
+                                    if (mafMode)
+                                        logDataTable.setValueAt(Double.valueOf(flds[logMafColIdx]), row, 10);
+                                    logDataTable.setValueAt(Double.valueOf(flds[logSdColIdx]), row, mafMode ? 11 : 10);
+                                    logDataTable.setValueAt(isClosed ? 1 : 0, row, mafMode ? 12 : 11);
                                     row += 1;
                                 }
                                 else
@@ -508,20 +579,27 @@ public class VECalc extends ACompCalc {
             else if (mpStr.contains("Rel") && sdStr.contains("Cobb"))
                 mapO = 14.7;
 
-            String rpmStr, iatStr, afrStr, mafStr, ffbStr;
+            String rpmStr, iatStr, afrStr, wbStr, afreStr, eclStr, eolStr, eStr, mafStr, ffbStr, clStr;
             LogData logData;
             xData = new HashMap<Double, HashMap<Double, ArrayList<LogData>>>();
             HashMap<Double, ArrayList<LogData>> yData;
             ArrayList<LogData> data;
+            boolean mafMode = (dataType.getSelectedIndex() == 0);
             for (int i = 0; i < logDataTable.getRowCount(); ++i) {
                 rpmStr = logDataTable.getValueAt(i, 0).toString();
                 iatStr = logDataTable.getValueAt(i, 1).toString();
                 mpStr  = logDataTable.getValueAt(i, 2).toString();
                 ffbStr = logDataTable.getValueAt(i, 3).toString();
                 afrStr = logDataTable.getValueAt(i, 4).toString();
-                mafStr = logDataTable.getValueAt(i, 5).toString();
-                sdStr  = logDataTable.getValueAt(i, 6).toString();
-                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afrStr.isEmpty() || mafStr.isEmpty() || ffbStr.isEmpty() || sdStr.isEmpty())
+                wbStr  = logDataTable.getValueAt(i, 5).toString();
+                afreStr = logDataTable.getValueAt(i, 6).toString();
+                eclStr = logDataTable.getValueAt(i, 7).toString();
+                eolStr = logDataTable.getValueAt(i, 8).toString();
+                eStr   = logDataTable.getValueAt(i, 9).toString();
+                mafStr = mafMode ? logDataTable.getValueAt(i, 10).toString() : "";
+                sdStr  = logDataTable.getValueAt(i, mafMode ? 11 : 10).toString();
+                clStr  = logDataTable.getValueAt(i, mafMode ? 12 : 11).toString();
+                if (rpmStr.isEmpty() || mpStr.isEmpty() || iatStr.isEmpty() || afreStr.isEmpty() || (mafMode && mafStr.isEmpty()) || ffbStr.isEmpty() || sdStr.isEmpty())
                     continue;
                 logData = new LogData();
                 logData.mp = (Double.valueOf(mpStr) * mapG) + mapO;
@@ -533,15 +611,29 @@ public class VECalc extends ACompCalc {
                 logData.mp = xAxisArray.get(Utils.closestValueIndex(logData.mp, xAxisArray));
                 logData.rpm = yAxisArray.get(Utils.closestValueIndex(logData.rpm, yAxisArray));
                 logData.iat = Double.valueOf(iatStr);
-                logData.maf = Double.valueOf(mafStr);
-                logData.sd = Double.valueOf(sdStr);
-                logData.afr = Double.valueOf(afrStr);
+                if (mafMode) {
+                    logData.maf = Double.valueOf(mafStr);
+                    logData.sd = Double.valueOf(sdStr);
+                } else {
+                    logData.maf = Double.NaN;
+                    logData.sd = Double.valueOf(sdStr);
+                }
+                logData.afrStock = Double.valueOf(afrStr);
+                logData.afrWb = Double.valueOf(wbStr);
+                logData.afr = Double.valueOf(afreStr);
+                logData.afrerrCl = Double.valueOf(eclStr);
+                logData.afrerrOl = Double.valueOf(eolStr);
+                logData.afrerr = Double.valueOf(eStr);
+                try {
+                    logData.cl = Integer.parseInt(clStr);
+                } catch (Exception ex) {
+                    logData.cl = 0;
+                }
                 logData.ffb = Double.valueOf(ffbStr);
-                logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
-                if (isOl)
-                    logData.afrerr = ((logData.afr - logData.ffb) / logData.ffb) * 100.0;
+                if (mafMode)
+                    logData.sderr = ((logData.sd - logData.maf) / logData.maf) * 100.0;
                 else
-                    logData.afrerr = trims.get(i);// + ((14.7 - logData.ffb) / 14.7 * 100);
+                    logData.sderr = 0.0;
                 
                 yData = xData.get(logData.mp);
                 if (yData == null) {
@@ -634,9 +726,28 @@ public class VECalc extends ACompCalc {
     }
     
     private void clearChartData() {
-        trims.clear();
         runData.clear();
         trendData.clear();
+    }
+
+    private void updateMafColumnVisibility() {
+        if (mafColumn == null || logDataTable == null)
+            return;
+        boolean isMafMode = (dataType.getSelectedIndex() == 0);
+        TableColumnModel model = logDataTable.getColumnModel();
+        boolean hasColumn;
+        try {
+            model.getColumnIndex(mafColumn.getIdentifier());
+            hasColumn = true;
+        } catch (IllegalArgumentException ex) {
+            hasColumn = false;
+        }
+        if (isMafMode && !hasColumn) {
+            model.addColumn(mafColumn);
+            model.moveColumn(model.getColumnCount() - 1, 10);
+        } else if (!isMafMode && hasColumn) {
+            model.removeColumn(mafColumn);
+        }
     }
     
     protected void clearLogDataTables() {

--- a/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
+++ b/src/com/vgi/mafscaling/VEColumnsFiltersSelection.java
@@ -22,12 +22,13 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
+import javax.swing.JFormattedTextField;
+import javax.swing.JSpinner;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -38,32 +39,45 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     private JScrollPane pane = null;
     JPanel selectionPanel = null;
     private String[] columns = null;
-    private boolean isOl = true;
+    private boolean isFullOl = false;
+    private boolean mafMode = true;
+    private JFormattedTextField maxAfrWbFilter = null;
+    private JFormattedTextField minAfrWbFilter = null;
+    private JFormattedTextField maxAfrClFilter = null;
+    private JFormattedTextField minAfrClFilter = null;
+    private JSpinner clStatusFilter = null;
+    private JSpinner olStatusFilter = null;
+    private JFormattedTextField olThrtlMinimumFilter = null;
+
+    public VEColumnsFiltersSelection() {
+        this(true);
+    }
+
+    public VEColumnsFiltersSelection(boolean mafMode) {
+        this.mafMode = mafMode;
+    }
     
     public boolean getUserSettings(String[] cols) {
         columns = cols;
         createScrollPane();
-
-        final JComboBox<String> clOlSelection = new JComboBox<String>(new String [] { "Open Loop", "Closed Loop" });
-        clOlSelection.addItemListener(new ItemListener() {
-            public void itemStateChanged(ItemEvent e) {
-                if(e.getStateChange() == ItemEvent.SELECTED) {
-                    isOl = (clOlSelection.getSelectedIndex() == 0? true: false);
-                    selectionPanel.remove(columnsPanel);
-                    selectionPanel.remove(filtersPanel);
-                    createColumnsPanel(columns);
-                    createFiltersPanel();
-                    selectionPanel.add(columnsPanel);
-                    selectionPanel.add(filtersPanel);
-                    selectionPanel.revalidate();
-                    selectionPanel.repaint();
-                    pane.setPreferredSize(new Dimension(windowWidth, windowHeight));
-                    SwingUtilities.invokeLater(new Runnable() { public void run() { pane.getVerticalScrollBar().setValue(0); } });
-                }
+        final JComboBox<String> modeSelection = new JComboBox<String>(new String [] { "CL/OL", "Full Time OL" });
+        modeSelection.addItemListener(e -> {
+            if(e.getStateChange() == ItemEvent.SELECTED) {
+                isFullOl = (modeSelection.getSelectedIndex() == 1);
+                selectionPanel.remove(columnsPanel);
+                selectionPanel.remove(filtersPanel);
+                createColumnsPanel(columns);
+                createFiltersPanel();
+                selectionPanel.add(columnsPanel);
+                selectionPanel.add(filtersPanel);
+                selectionPanel.revalidate();
+                selectionPanel.repaint();
+                pane.setPreferredSize(new Dimension(windowWidth, windowHeight));
+                SwingUtilities.invokeLater(() -> pane.getVerticalScrollBar().setValue(0));
             }
         });
-        
-        JComponent[] inputs = new JComponent[] {clOlSelection, pane};
+
+        JComponent[] inputs = new JComponent[] {modeSelection, pane};
         // bring scroll pane to the start
         SwingUtilities.invokeLater(new Runnable() { public void run() { pane.getVerticalScrollBar().setValue(0); } });
         
@@ -93,11 +107,9 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
     }
     
     protected void addColSelection() {
-        if (isOl) {
-            addWidebandAFRColSelection();
-        }
-        else {
-            addStockAFRColSelection();
+        addWidebandAFRColSelection();
+        addStockAFRColSelection();
+        if (!isFullOl) {
             addAFCorrectionColSelection();
             addAFLearningColSelection();
         }
@@ -106,28 +118,43 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         addThrottleAngleColSelection();
         addManifoldPressureColSelection();
         addFFBColSelection();
-        addClOlStatusColSelection();
-        addMAFColSelection();
+        if (!isFullOl)
+            addClOlStatusColSelection();
+        if (mafMode)
+            addMAFColSelection();
         addVEFlowColSelection();
     }
     
     protected void addFilterSelection() {
         addThrottleChangeMaximumFilter();
         thrtlChangeMaxFilter.setValue(Config.getVEThrottleChangeMaxValue());
-        if (isOl) {
-            addThrottleMinimumFilter();
-            thrtlMinimumFilter.setValue(Config.getVEThrottleMinimumValue());
-            addAFRMaximumFilter();
-            maxAfrFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
+        addThrottleMinimumFilter();
+        thrtlMinimumFilter.setValue(Config.getVEThrottleMinimumValue());
+        if (!isFullOl) {
+            addOlThrottleMinimumFilter();
+            olThrtlMinimumFilter.setText(String.valueOf(Config.getVEOlThrottleMinimumValue()));
         }
-        else {
-            addAFRMaximumFilter();
-            maxAfrFilter.setText(String.valueOf(Config.getVEClAfrMaximumValue()));
-            addAFRMinimumFilter();
-            minAfrFilter.setText(String.valueOf(Config.getVEAfrMinimumValue()));
+        addWbAFRMaximumFilter();
+        maxAfrWbFilter.setText(String.valueOf(Config.getVEOlAfrMaximumValue()));
+        addWbAFRMinimumFilter();
+        minAfrWbFilter.setText(String.valueOf(Config.getVEOlAfrMinimumValue()));
+        if (isFullOl) {
+            addStockAFRMaximumFilter();
+            maxAfrClFilter.setText(String.valueOf(Config.getVEClAfrMaximumValue()));
+            addStockAFRMinimumFilter();
+            minAfrClFilter.setText(String.valueOf(Config.getVEClAfrMinimumValue()));
+            addAfrMpSwitchFilter();
+            afrMpSwitchFilter.setText(String.valueOf(Config.getVEWbAfrMpSwitch()));
+            addAfrRpmSwitchFilter();
+            afrRpmSwitchFilter.setText(String.valueOf(Config.getVEWbAfrRpmSwitch()));
+            addAfrSmoothFilter();
+            afrSmoothFilter.setText(String.valueOf(Config.getVEWbAfrSmooth()));
+        } else {
+            addClStatusFilter();
+            clStatusFilter.setValue(Config.getVEClStatusValue());
+            addOlStatusFilter();
+            olStatusFilter.setValue(Config.getVEOlStatusValue());
         }
-        addCLOLStatusFilter();
-        clolStatusFilter.setValue(Config.getVEClOlStatusValue());
         addIATMaximumFilter();
         maxIatFilter.setText(String.valueOf(Config.getVEIatMaximumValue()));
         addRPMMinimumFilter();
@@ -138,10 +165,8 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         maxFFBFilter.setText(String.valueOf(Config.getFFBMaximumValue()));
         addFFBMinimumFilter();
         minFFBFilter.setText(String.valueOf(Config.getFFBMinimumValue()));
-        if (isOl) {
-            addWideBandAFRRowOffsetFilter();
-            wbo2RowOffsetField.setText(String.valueOf(Config.getWBO2RowOffset()));
-        }
+        addWideBandAFRRowOffsetFilter();
+        wbo2RowOffsetField.setText(String.valueOf(Config.getWBO2RowOffset()));
         addCellHitCountMinimumFilter();
         minCellHitCountFilter.setText(String.valueOf(Config.getVEMinCellHitCount()));
         addCorrectionAppliedValue();
@@ -152,14 +177,12 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
                 JEditorPane label = (JEditorPane)c;
                 if (label.getText().startsWith("Remove data where Throttle Input is below"))
                     label.setText(label.getText() + " (*** works with AFR Maximum filter)");
-                else if (isOl && label.getText().startsWith("Remove data where AFR is above"))
+                else if (label.getText().startsWith("Remove data where AFR is above"))
                     label.setText(label.getText() + "(*** works with Throttle Input Minimum filter)");
                 else if (label.getText().startsWith("Remove data where RPM is below"))
                     label.setText(label.getText() + " (hint: check min RPM in SD table (y-axis)");
                 else if (label.getText().startsWith("Remove data where Manifold Pressure is below"))
                     label.setText(label.getText() + " (hint: check min MP in SD table (x-axis)");
-                else if (label.getText().equals(clolStatusLabelText))
-                    label.setText(clolStatusLabelText + " *");
             }
         }
     }
@@ -169,30 +192,27 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         String value;
         String colName;
         
-        Config.veOpenLoop(isOl);
-
-        if (isOl) {
-            // Wideband AFR
-            value = wbAfrName.getText().trim();
-            colName = wbAfrLabelText;
-            if (value.isEmpty()) {
-                ret = false;
-                error.append("\"").append(colName).append("\" column must be specified\n");
-            }
-            else
-                Config.setWidebandAfrColumnName(value);
+        // Wideband AFR
+        value = wbAfrName.getText().trim();
+        colName = wbAfrLabelText;
+        if (value.isEmpty()) {
+            ret = false;
+            error.append("\"").append(colName).append("\" column must be specified\n");
         }
-        else {
-            // Stock AFR
-            value = stockAfrName.getText().trim();
-            colName = stockAfrLabelText;
-            if (value.isEmpty()) {
-                ret = false;
-                error.append("\"").append(colName).append("\" column must be specified\n");
-            }
-            else
-                Config.setAfrColumnName(value);
+        else
+            Config.setWidebandAfrColumnName(value);
 
+        // Stock AFR
+        value = stockAfrName.getText().trim();
+        colName = stockAfrLabelText;
+        if (value.isEmpty()) {
+            ret = false;
+            error.append("\"").append(colName).append("\" column must be specified\n");
+        }
+        else
+            Config.setAfrColumnName(value);
+
+        if (!isFullOl) {
             // AFR Learning
             value = afLearningName.getText().trim();
             colName = afLearningLabelText;
@@ -202,7 +222,7 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
             }
             else
                 Config.setAfLearningColumnName(value);
-            
+
             // AFR Correction
             value = afCorrectionName.getText().trim();
             colName = afCorrectionLabelText;
@@ -212,7 +232,6 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
             }
             else
                 Config.setAfCorrectionColumnName(value);
-            
         }
         
         // Engine Speed
@@ -265,25 +284,31 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         else
             Config.setFinalFuelingBaseColumnName(value);
 
-        // CL/OL Status
-        value = clolStatusName.getText().trim();
-        colName = clolStatusLabelText;
-        if (value.isEmpty()) {
-            ret = false;
-            error.append("\"").append(colName).append("\" column must be specified\n");
+        if (!isFullOl) {
+            // CL/OL Status
+            value = clolStatusName.getText().trim();
+            colName = clolStatusLabelText;
+            if (value.isEmpty()) {
+                ret = false;
+                error.append("\"").append(colName).append("\" column must be specified\n");
+            }
+            else
+                Config.setClOlStatusColumnName(value);
         }
-        else
-            Config.setClOlStatusColumnName(value);
 
-        // MAF
-        value = mafName.getText().trim();
-        colName = mafLabelText;
-        if (value.isEmpty()) {
-            ret = false;
-            error.append("\"").append(colName).append("\" column must be specified\n");
+        if (mafMode) {
+            // MAF
+            value = mafName.getText().trim();
+            colName = mafLabelText;
+            if (value.isEmpty()) {
+                ret = false;
+                error.append("\"").append(colName).append("\" column must be specified\n");
+            }
+            else
+                Config.setMassAirflowColumnName(value);
+        } else {
+            Config.setMassAirflowColumnName(Config.NO_NAME);
         }
-        else
-            Config.setMassAirflowColumnName(value);
 
         // VE Flow
         value = veFlowName.getText().trim();
@@ -298,26 +323,30 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         // Throttle Change % Maximum
         Config.setVEThrottleChangeMaxValue(Integer.valueOf(thrtlChangeMaxFilter.getValue().toString()));
 
-        if (isOl) {
-            // Throttle Minimum Input
-            Config.setVEThrottleMinimumValue(Integer.valueOf(thrtlMinimumFilter.getText()));
-            
-            // AFR Maximum
-            Config.setVEOlAfrMaximumValue(Double.valueOf(maxAfrFilter.getText()));
-            
-            // WBO2 Row Offset
-            Config.setWBO2RowOffset(Integer.valueOf(wbo2RowOffsetField.getText()));
+        // Throttle Minimum Input
+        Config.setVEThrottleMinimumValue(Integer.valueOf(thrtlMinimumFilter.getText()));
+        if (!isFullOl)
+            Config.setVEOlThrottleMinimumValue(Integer.valueOf(olThrtlMinimumFilter.getText()));
+
+        // AFR filters
+        Config.setVEOlAfrMaximumValue(Double.valueOf(maxAfrWbFilter.getText()));
+        Config.setVEOlAfrMinimumValue(Double.valueOf(minAfrWbFilter.getText()));
+        if (isFullOl) {
+            Config.setVEClAfrMaximumValue(Double.valueOf(maxAfrClFilter.getText()));
+            Config.setVEClAfrMinimumValue(Double.valueOf(minAfrClFilter.getText()));
         }
-        else {
-            // AFR Maximum
-            Config.setVEClAfrMaximumValue(Double.valueOf(maxAfrFilter.getText()));
-            
-            // AFR Minimum
-            Config.setVEAfrMinimumValue(Double.valueOf(minAfrFilter.getText()));
+
+        // WBO2 Row Offset
+        Config.setWBO2RowOffset(Integer.valueOf(wbo2RowOffsetField.getText()));
+
+        if (isFullOl) {
+            Config.setVEWbAfrMpSwitch(Double.valueOf(afrMpSwitchFilter.getText()));
+            Config.setVEWbAfrRpmSwitch(Integer.valueOf(afrRpmSwitchFilter.getText()));
+            Config.setVEWbAfrSmooth(Double.valueOf(afrSmoothFilter.getText()));
+        } else {
+            Config.setVEClStatusValue(Integer.valueOf(clStatusFilter.getValue().toString()));
+            Config.setVEOlStatusValue(Integer.valueOf(olStatusFilter.getValue().toString()));
         }
-        
-        // CL/OL Status
-        Config.setVEClOlStatusValue(Integer.valueOf(clolStatusFilter.getValue().toString()));
         
         // IAT filter
         Config.setVEIatMaximumValue(Double.valueOf(maxIatFilter.getText()));
@@ -337,8 +366,59 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
         
         // Correction applied
         Config.setVECorrectionAppliedValue(Integer.valueOf(correctionAppliedValue.getValue().toString()));
-        
+
+        Config.veFullTimeOl(isFullOl);
+
         return ret;
+    }
+
+    private void addWbAFRMaximumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where WB AFR is above the specified maximum");
+        addLabel(filtersPanel, ++filtrow, "WB AFR Maximum");
+        maxAfrWbFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "maxafrwb");
+    }
+
+    private void addWbAFRMinimumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where WB AFR is below the specified minimum");
+        addLabel(filtersPanel, ++filtrow, "WB AFR Minimum");
+        minAfrWbFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "minafrwb");
+    }
+
+    private void addStockAFRMaximumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where Stock AFR is above the specified maximum");
+        addLabel(filtersPanel, ++filtrow, "Stock AFR Maximum");
+        maxAfrClFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "maxafrstock");
+    }
+
+    private void addStockAFRMinimumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove data where Stock AFR is below the specified minimum");
+        addLabel(filtersPanel, ++filtrow, "Stock AFR Minimum");
+        minAfrClFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "minafrstock");
+    }
+
+    private void addClStatusFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Logged value indicating Closed Loop");
+        addLabel(filtersPanel, ++filtrow, "CL Status Value");
+        clStatusFilter = addSpinnerFilter(filtrow, Config.getVEClStatusValue(), -1, 10, 1);
+        addDefaultButton(filtrow, "clstatus");
+    }
+
+    private void addOlStatusFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Logged value indicating Open Loop");
+        addLabel(filtersPanel, ++filtrow, "OL Status Value");
+        olStatusFilter = addSpinnerFilter(filtrow, Config.getVEOlStatusValue(), -1, 10, 1);
+        addDefaultButton(filtrow, "olstatus");
+    }
+
+    private void addOlThrottleMinimumFilter() {
+        addNote(filtersPanel, ++filtrow, 3, "Remove OL data where Throttle Input is below the specified minimum");
+        addLabel(filtersPanel, ++filtrow, "OL Throttle Minimum");
+        olThrtlMinimumFilter = addTextFilter(filtrow, doubleFmt);
+        addDefaultButton(filtrow, "minolthrtl");
     }
     
     protected boolean processDefaultButton(ActionEvent e) {
@@ -354,20 +434,30 @@ public class VEColumnsFiltersSelection extends ColumnsFiltersSelection {
             maxFFBFilter.setText(Config.DefaultFFBMaximum);
         else if ("minffb".equals(e.getActionCommand()))
             minFFBFilter.setText(Config.DefaultFFBMinimum);
-        else if ("clolstatus".equals(e.getActionCommand()))
-            clolStatusFilter.setValue(Integer.valueOf(Config.DefaultClOlStatusValue));
+        else if ("clstatus".equals(e.getActionCommand()))
+            clStatusFilter.setValue(Integer.valueOf(Config.DefaultVEClStatusValue));
+        else if ("olstatus".equals(e.getActionCommand()))
+            olStatusFilter.setValue(Integer.valueOf(Config.DefaultVEOlStatusValue));
+        else if ("minolthrtl".equals(e.getActionCommand()))
+            olThrtlMinimumFilter.setValue(Integer.valueOf(Config.DefaultVEOlThrottleMinimum));
         else if ("minthrtl".equals(e.getActionCommand()))
             thrtlMinimumFilter.setValue(Integer.valueOf(Config.DefaultVEThrottleMinimum));
-        else if ("maxafr".equals(e.getActionCommand())) {
-            if (isOl)
-                maxAfrFilter.setText(Config.DefaultVEOlAfrMaximum);
-            else
-                maxAfrFilter.setText(Config.DefaultVEClAfrMaximum);
-        }
-        else if ("minafr".equals(e.getActionCommand()))
-            minAfrFilter.setText(Config.DefaultVEAfrMinimum);
+        else if ("maxafrwb".equals(e.getActionCommand()))
+            maxAfrWbFilter.setText(Config.DefaultVEOlAfrMaximum);
+        else if ("minafrwb".equals(e.getActionCommand()))
+            minAfrWbFilter.setText(Config.DefaultVEOlAfrMinimum);
+        else if ("maxafrstock".equals(e.getActionCommand()))
+            maxAfrClFilter.setText(Config.DefaultVEClAfrMaximum);
+        else if ("minafrstock".equals(e.getActionCommand()))
+            minAfrClFilter.setText(Config.DefaultVEClAfrMinimum);
         else if ("wbo2offset".equals(e.getActionCommand()))
             wbo2RowOffsetField.setText(Config.DefaultWBO2RowOffset);
+        else if ("wbswitchmp".equals(e.getActionCommand()))
+            afrMpSwitchFilter.setText(Config.DefaultVEWbAfrMpSwitch);
+        else if ("wbswitchrpm".equals(e.getActionCommand()))
+            afrRpmSwitchFilter.setText(Config.DefaultVEWbAfrRpmSwitch);
+        else if ("wbsmooth".equals(e.getActionCommand()))
+            afrSmoothFilter.setText(Config.DefaultVEWbAfrSmooth);
         else if ("minhitcnt".equals(e.getActionCommand()))
             minCellHitCountFilter.setText(Config.DefaultVEMinCellHitCount);
         else if ("corrapply".equals(e.getActionCommand()))

--- a/src/com/vgi/mafscaling/vecalc.properties
+++ b/src/com/vgi/mafscaling/vecalc.properties
@@ -4,7 +4,7 @@ usage=\
 This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which is used to build a VE base map using your current MAF.<br/>A special 'thank you' to 04ssti for testing this.<br/>\
 <p>There are essentially two main functions selectable via a drop down list:\
 <ul><li>MAF Builder - used to build Speed Density map based on your existing well working MAF scale by having your tune in MAF/SD mode</li>\
-<li>AFR Tuner - used to fine-tune existing SD table based on AFR. 'Closed Loop' or 'Open Loop' tuning can be selected when loading a log file</li><ul>\
+<li>AFR Tuner - used to fine-tune existing SD table based on AFR. Select between <b>CL/OL</b> (uses logged status) or <b>Full Time OL</b> when loading logs. In Full Time OL mode, AFR source is blended between Stock and Wideband based on MP/RPM filters (defaults: MP=1.0, RPM=3000, range=0.3).</li><ul>\
 <h3>Logic:</h3>\
 <p>The tool is for adjusting Speed Density VE table based on an adjustment which is calculated as a average of corrections for a specific table cell.<br/>\
 <p>The correction will only be applied to cells where count of corrections is more than the cell hit count specified in settings.<br/>\
@@ -32,7 +32,7 @@ This tool is a port of Merp's 32-Bit Speed Density Map Builder spreadsheet which
 <h3>Usage:</h3>\
 <i></i>You really need to nail MAF scaling first!<br/><br/>\
 <ol style="list-style-type: decimal">\
-<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and/or &quot;Stock AFR&quot; (for CL/OL), &quot;Mass Airflow&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status". \
+<li>Log &quot;Engine Speed&quot;, &quot;Throttle Angle %&quot;, &quot;Manifold Pressure&quot, &quot;IAT&quot;, &quot;Wideband AFR&quot; and &quot;Stock AFR&quot;, &quot;Final Fueling Base&quot;, &quot;Volumetric Efficiency&quot;, and "CL/OL Status" (for CL/OL mode). Log &quot;Mass Airflow&quot; only when using MAF Builder mode. \
 <li>Open your tune in RomRaider/Cobb AP and copy your current VE table into the first cell of &quot;Current VE table&quot; table on the tool.</li>\
 <li>Click on &quot;Load Log&quot; button, select your log file(s), select asked columns from log file AND set desired filters values. Once the log file is processed you should see data populated in the table</li>\
 <li>Select SD implementation you have from the drop down menu.</li>\


### PR DESCRIPTION
## Summary
- track stock, wideband, and effective AFR along with separate CL and OL error percentages
- allow configuration of CL and OL status values plus an open-loop throttle filter in VE log loading
- expose defaults for new filters and make spinner helpers reusable

## Testing
- ⚠️ `apt-get install -y ant` (ca-certificates-java failed to configure)
- ✅ `ant jar`


------
https://chatgpt.com/codex/tasks/task_e_6889726309dc833182559da2630bf98f